### PR TITLE
Skip using resolvconf (more dhcp/dns fixes)

### DIFF
--- a/crates/krun-guest/src/bin/krun-guest.rs
+++ b/crates/krun-guest/src/bin/krun-guest.rs
@@ -1,7 +1,6 @@
 use std::cmp;
 use std::os::unix::process::CommandExt as _;
 use std::process::Command;
-
 use anyhow::{Context, Result};
 use krun_guest::cli_options::options;
 use krun_guest::fex::setup_fex;
@@ -39,6 +38,8 @@ fn main() -> Result<()> {
         return Err(err).context("Failed to mount filesystems, bailing out");
     }
     Command::new("/usr/lib/systemd/systemd-udevd").spawn()?;
+    Command::new("/usr/bin/udevadm").arg("trigger").spawn()?.wait()?;
+    Command::new("/usr/bin/udevadm").arg("settle").spawn()?.wait()?;
 
     setup_fex()?;
 

--- a/crates/krun-guest/src/net.rs
+++ b/crates/krun-guest/src/net.rs
@@ -28,7 +28,7 @@ pub fn configure_network() -> Result<()> {
     };
     if let Some(dhcpcd_path) = dhcpcd_path {
         let output = Command::new(dhcpcd_path)
-            .args(["-M", "--nodev", "eth0"])
+            .args(["-M", "eth0", "-e", "resolvconf=does-not-exist"])
             .output()
             .context("Failed to execute `dhcpcd` as child process")?;
         debug!(output:?; "dhcpcd output");


### PR DESCRIPTION
On systems with systemd-resolved installed, dhcpcd tries to use resolvconf to configure the dns server. Naturally this fails, as we do not have systemd &co inside the vm.