### PR TITLE
Autoconfigure network without DHCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "backtrace"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,16 +234,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
-name = "futures-core"
-version = "0.3.30"
+name = "futures"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -372,9 +455,12 @@ dependencies = [
  "bpaf",
  "byteorder",
  "env_logger",
+ "futures-util",
  "krun-sys",
  "log",
- "nix",
+ "nix 0.28.0",
+ "regex",
+ "rtnetlink",
  "rustix",
  "serde",
  "serde_json",
@@ -382,6 +468,82 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -426,10 +588,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
@@ -451,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -463,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -474,9 +648,27 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rtnetlink"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.27.1",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -556,6 +748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +787,26 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -13,10 +13,13 @@ anyhow = { version = "1.0.82", default-features = false, features = ["std"] }
 bpaf = { version = "0.9.11", default-features = false, features = [] }
 byteorder = { version = "1.5.0", default-features = false, features = ["std"] }
 env_logger = { version = "0.11.3", default-features = false, features = ["auto-color", "humantime", "unstable-kv"] }
+futures-util = { version = "0.3.30", default-features = false, features = [] }
 krun-sys = { path = "../krun-sys", version = "1.9.1", default-features = false, features = [] }
 log = { version = "0.4.21", default-features = false, features = ["kv"] }
 nix = { version = "0.28.0", default-features = false, features = ["user"] }
+regex = { version = "1.10.6" }
 rustix = { version = "0.38.34", default-features = false, features = ["fs", "mount", "process", "std", "system", "use-libc-auxv"] }
+rtnetlink = { version = "0.14.1" }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.117", default-features = false, features = ["std"] }
 tempfile = { version = "3.10.1", default-features = false, features = [] }

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -233,13 +233,19 @@ fn main() -> Result<()> {
         }
     }
 
+    let mut env = prepare_env_vars(env).context("Failed to prepare environment variables")?;
+    env.insert(
+        "MUVM_SERVER_PORT".to_owned(),
+        options.server_port.to_string(),
+    );
+
     {
         let passt_fd: OwnedFd = if let Some(passt_socket) = options.passt_socket {
             connect_to_passt(passt_socket)
                 .context("Failed to connect to `passt`")?
                 .into()
         } else {
-            start_passt(options.server_port)
+            start_passt(options.server_port, &mut env)
                 .context("Failed to start `passt`")?
                 .into()
         };
@@ -354,12 +360,6 @@ fn main() -> Result<()> {
     for arg in command_args {
         muvm_guest_args.push(arg);
     }
-
-    let mut env = prepare_env_vars(env).context("Failed to prepare environment variables")?;
-    env.insert(
-        "MUVM_SERVER_PORT".to_owned(),
-        options.server_port.to_string(),
-    );
 
     let mut krun_config = KrunConfig {
         args: Vec::new(),

--- a/crates/muvm/src/guest/mount.rs
+++ b/crates/muvm/src/guest/mount.rs
@@ -138,8 +138,6 @@ pub fn mount_filesystems() -> Result<()> {
         println!("Failed to mount FEX rootfs, carrying on without.")
     }
 
-    place_etc("resolv.conf", None)?;
-
     mount2(
         Some("binfmt_misc"),
         "/proc/sys/fs/binfmt_misc",

--- a/crates/muvm/src/net.rs
+++ b/crates/muvm/src/net.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::os::fd::{AsRawFd, IntoRawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
@@ -5,6 +6,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result};
 use log::debug;
+use regex::Regex;
 use rustix::io::dup;
 
 pub fn connect_to_passt<P>(passt_socket_path: P) -> Result<UnixStream>
@@ -14,7 +16,7 @@ where
     Ok(UnixStream::connect(passt_socket_path)?)
 }
 
-pub fn start_passt(server_port: u32) -> Result<UnixStream> {
+pub fn start_passt(server_port: u32, env: &mut HashMap<String, String>) -> Result<UnixStream> {
     // SAFETY: The child process should not inherit the file descriptor of
     // `parent_socket`. There is no documented guarantee of this, but the
     // implementation as of writing atomically sets `SOCK_CLOEXEC`.
@@ -38,14 +40,70 @@ pub fn start_passt(server_port: u32) -> Result<UnixStream> {
     // SAFETY: `child_fd` is an `OwnedFd` and consumed to prevent closing on drop,
     // as it will now be owned by the child process.
     // See https://doc.rust-lang.org/std/io/index.html#io-safety
-    let child = Command::new("passt")
-        .args(["-q", "-f", "-t"])
+    let output = Command::new("passt")
+        .args(["-t"])
         .arg(format!("{server_port}:{server_port}"))
         .arg("--fd")
         .arg(format!("{}", child_fd.into_raw_fd()))
-        .spawn();
-    if let Err(err) = child {
-        return Err(err).context("Failed to execute `passt` as child process");
+        .output()
+        .context("Failed to execute `passt` as child process")?;
+
+    let content = String::from_utf8(output.stderr).context("Failed to parse `passt` output")?;
+
+    let re =
+        Regex::new(r".*assign: (?<address>.+)\n.*mask: (?<mask>.+)\n.*router: (?<router>.+).*\n")
+            .unwrap();
+    if let Some(caps) = re.captures(&content) {
+        if let Some(address) = caps.name("address") {
+            env.insert(
+                "MUVM_NETWORK_ADDRESS".to_owned(),
+                address.as_str().to_string(),
+            );
+        } else {
+            println!("Can't read network address from passt output. Expect degraded networking");
+        }
+        if let Some(mask) = caps.name("mask") {
+            env.insert("MUVM_NETWORK_MASK".to_owned(), mask.as_str().to_string());
+        } else {
+            println!("Can't read network mask from passt output. Expect degraded networking");
+        }
+        if let Some(router) = caps.name("router") {
+            env.insert(
+                "MUVM_NETWORK_ROUTER".to_owned(),
+                router.as_str().to_string(),
+            );
+        } else {
+            println!("Can't read network router from passt output. Expect degraded networking");
+        }
+    }
+
+    if let Some(dns_index) = content.find("DNS:") {
+        let dns_data = &content[dns_index + 5..];
+        let mut i = 1;
+        for line in dns_data.split("\n") {
+            if line.starts_with("    ") {
+                env.insert(
+                    format!("MUVM_NETWORK_DNS{}", i).to_owned(),
+                    line.trim().to_string(),
+                );
+                if i == 3 {
+                    // MAXNS == 3, ignore the rest.
+                    break;
+                }
+                i += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    if let Some(search_index) = content.find("DNS search list:") {
+        let search_data = &content[search_index + 17..];
+        for line in search_data.split("\n") {
+            if line.starts_with("    ") {
+                env.insert("MUVM_NETWORK_SEARCH".to_owned(), line.trim().to_string());
+            }
+        }
     }
 
     Ok(parent_socket)


### PR DESCRIPTION
Passt includes a DHCP server to allow guests to easily configure the network without being aware passt is on the other side. But we _are_ aware of that, so we can take advantage of it.

Instead of using DHCP, read the configuration output from passt, marshall it into some environment variables, pass it to the guest, and have krun-guest read it and apply it using rtnetlink.

By doing that, we reduce the startup time in half, from...

$ time krun /bin/false
(...)
real    0m4,301s

... to ...

$ time krun /bin/false
(...)
real    0m1,966s