### PR TITLE
Basic x112virtgpu support

### DIFF
--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -361,6 +361,18 @@ fn main() -> Result<()> {
         options.server_port.to_string(),
     );
 
+    if options.direct_x11 {
+        let display =
+            env::var("DISPLAY").context("X11 forwarding requested but DISPLAY is unset")?;
+        env.insert("HOST_DISPLAY".to_string(), display);
+
+        // And forward XAUTHORITY. This will be modified to fix the
+        // display name in muvm-guest.
+        if let Ok(xauthority) = env::var("XAUTHORITY") {
+            env.insert("XAUTHORITY".to_string(), xauthority);
+        }
+    }
+
     let mut krun_config = KrunConfig {
         args: Vec::new(),
         envs: Vec::new(),

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -287,7 +287,7 @@ fn main() -> Result<()> {
 
     // Forward the native X11 display into the guest as a socket
     if let Ok(x11_display) = env::var("DISPLAY") {
-        if let Some(x11_display) = x11_display.strip_prefix(":") {
+        if let Some(x11_display) = x11_display.strip_prefix(':') {
             let socket_path = Path::new("/tmp/.X11-unix/").join(format!("X{}", x11_display));
             if socket_path.exists() {
                 let socket_path = CString::new(

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -15,6 +15,7 @@ pub struct Options {
     pub passt_socket: Option<PathBuf>,
     pub server_port: u32,
     pub fex_images: Vec<String>,
+    pub direct_x11: bool,
     pub command: PathBuf,
     pub command_args: Vec<String>,
 }
@@ -98,6 +99,11 @@ pub fn options() -> OptionParser<Options> {
         .argument("SERVER_PORT")
         .fallback(3334)
         .display_fallback();
+    let direct_x11 = long("direct-x11")
+        .short('x')
+        .help("Use direct X11 forwarding instead of sommelier + XWayland")
+        .switch();
+
     let command = positional("COMMAND").help("the command you want to execute in the vm");
     let command_args = any::<String, _, _>("COMMAND_ARGS", |arg| {
         (!["--help", "-h"].contains(&&*arg)).then_some(arg)
@@ -113,6 +119,7 @@ pub fn options() -> OptionParser<Options> {
         passt_socket,
         server_port,
         fex_images,
+        direct_x11,
         // positionals
         command,
         command_args,

--- a/crates/muvm/src/env.rs
+++ b/crates/muvm/src/env.rs
@@ -64,19 +64,6 @@ pub fn prepare_env_vars(env: Vec<(String, Option<String>)>) -> Result<HashMap<St
         env_map.insert(key, value);
     }
 
-    // If we have an X11 display in the host, set HOST_DISPLAY in the guest.
-    // muvm-guest will then use this to set up xauth and replace it with :1
-    // (which is forwarded to the host display).
-    if let Ok(display) = env::var("DISPLAY") {
-        env_map.insert("HOST_DISPLAY".to_string(), display);
-
-        // And forward XAUTHORITY. This will be modified to fix the
-        // display name in muvm-guest.
-        if let Ok(xauthority) = env::var("XAUTHORITY") {
-            env_map.insert("XAUTHORITY".to_string(), xauthority);
-        }
-    }
-
     debug!(env:? = env_map; "env vars");
 
     Ok(env_map)

--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -61,13 +61,13 @@ fn main() -> Result<()> {
     let pulse_path = pulse_path.join("native");
     setup_socket_proxy(pulse_path, 3333)?;
 
-    setup_x11_forwarding(run_path)?;
+    if !setup_x11_forwarding(run_path)? {
+        // Will not return if successful.
+        exec_sommelier(&options.command, &options.command_args)
+            .context("Failed to execute sommelier")?;
+    }
 
-    // Will not return if successful.
-    exec_sommelier(&options.command, &options.command_args)
-        .context("Failed to execute sommelier")?;
-
-    // Fallback option if sommelier is not present.
+    // Fallback option if sommelier is not present or for direct X11 mode.
     debug!(command:? = options.command, command_args:? = options.command_args; "exec");
     let err = Command::new(&options.command)
         .args(options.command_args)

--- a/crates/muvm/src/guest/x11.rs
+++ b/crates/muvm/src/guest/x11.rs
@@ -21,7 +21,7 @@ where
         Err(_) => return Ok(()),
     };
 
-    if !host_display.starts_with(":") {
+    if !host_display.starts_with(':') {
         return Err(anyhow!("Invalid host DISPLAY"));
     }
     let host_display = &host_display[1..];


### PR DESCRIPTION
Replace the trivial X11 socket passthrough with x112virtgpu, if it is installed and DAX is enabled. This lives alongside the existing sommelier solution, so we can test both options for now.