### PR TITLE
guest/net: Handle missing /etc/hostname gracefully

### DIFF
--- a/crates/muvm/src/guest/net.rs
+++ b/crates/muvm/src/guest/net.rs
@@ -24,7 +24,7 @@ pub fn configure_network() -> Result<()> {
 
     {
         let hostname =
-            fs::read_to_string("/etc/hostname").context("Failed to read `/etc/hostname`")?;
+            fs::read_to_string("/etc/hostname").unwrap_or("placeholder-hostname".to_string());
         let hostname = if let Some((hostname, _)) = hostname.split_once('\n') {
             hostname.to_owned()
         } else {


### PR DESCRIPTION
The error handled in #74 was muvm-guest's network code. So fixing it there directly. Not sure if any of the actual binaries running in the guest actually care about `/etc/hostname`.