### PR TITLE
muvm-guest: Support root and user init scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
+ "xdg",
 ]
 
 [[package]]
@@ -807,3 +808,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -23,6 +23,7 @@ tempfile = { version = "3.10.1", default-features = false, features = [] }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util", "macros", "net", "process", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1.15", default-features = false, features = ["net", "sync"] }
 uuid = { version = "1.10.0", default-features = false, features = ["std", "v7"] }
+xdg = "2.5.2"
 
 [features]
 default = []


### PR DESCRIPTION
Introduce two scripts that can be placed in ~/.local/share/muvm

- init.sh: Executed as root, before dropping privileges
- user.sh: Executed as the user, after dropping privileges

If the files are also present in lower-priority XDG dirs (systemwide), those are executed first.

This makes it possible to add custom VM configuration and setup or debugging scripts without having to hack on the muvm code.