### PR TITLE
muvm-guest: Reopen the system tty (hvc0)

### DIFF
--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = { version = "0.11.3", default-features = false, features = ["auto-c
 krun-sys = { path = "../krun-sys", version = "1.9.1", default-features = false, features = [] }
 log = { version = "0.4.21", default-features = false, features = ["kv"] }
 nix = { version = "0.28.0", default-features = false, features = ["user"] }
-rustix = { version = "0.38.34", default-features = false, features = ["fs", "mount", "process", "std", "system", "use-libc-auxv"] }
+rustix = { version = "0.38.34", default-features = false, features = ["fs", "mount", "process", "std", "stdio", "system", "use-libc-auxv"] }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.117", default-features = false, features = ["std"] }
 tempfile = { version = "3.10.1", default-features = false, features = [] }


### PR DESCRIPTION
This fixes the classic:

-bash: cannot set terminal process group (-1): Inappropriate ioctl for device
-bash: no job control in this shell

I'm not entirely sure why this doesn't happen with our main shell, but it happens with things like sudo. (There are a bunch of other things needed to make sudo work, of course)