### PR TITLE
Protect muvm-server, spawn one as root and monitor available host memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +381,7 @@ dependencies = [
  "krun-sys",
  "log",
  "nix",
+ "procfs",
  "rustix",
  "serde",
  "serde_json",
@@ -438,6 +445,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags",
+ "hex",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags",
+ "hex",
 ]
 
 [[package]]

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = { version = "1.0.117", default-features = false, features = ["std"]
 tempfile = { version = "3.10.1", default-features = false, features = [] }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util", "macros", "net", "process", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1.15", default-features = false, features = ["net", "sync"] }
-uuid = { version = "1.10.0", default-features = false, features = ["std", "v7"] }
+uuid = { version = "1.10.0", default-features = false, features = ["serde", "std", "v7"] }
 
 [features]
 default = []

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = { version = "0.11.3", default-features = false, features = ["auto-c
 krun-sys = { path = "../krun-sys", version = "1.9.1", default-features = false, features = [] }
 log = { version = "0.4.21", default-features = false, features = ["kv"] }
 nix = { version = "0.28.0", default-features = false, features = ["user"] }
+procfs = { version = "0.17.0", default-features = false, features = [] }
 rustix = { version = "0.38.34", default-features = false, features = ["fs", "mount", "process", "std", "stdio", "system", "use-libc-auxv"] }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.117", default-features = false, features = ["std"] }

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
 
     let options = options().fallback_to_usage().run();
 
-    let (_lock_file, command, command_args, env) = match launch_or_lock(
+    let (cookie, _lock_file, command, command_args, env) = match launch_or_lock(
         options.server_port,
         options.command,
         options.command_args,
@@ -79,11 +79,12 @@ fn main() -> Result<()> {
             return Ok(());
         },
         LaunchResult::LockAcquired {
+            cookie,
             lock_file,
             command,
             command_args,
             env,
-        } => (lock_file, command, command_args, env),
+        } => (cookie, lock_file, command, command_args, env),
     };
 
     {
@@ -374,6 +375,7 @@ fn main() -> Result<()> {
         "MUVM_SERVER_PORT".to_owned(),
         options.server_port.to_string(),
     );
+    env.insert("MUVM_SERVER_COOKIE".to_owned(), cookie.to_string());
 
     if options.direct_x11 {
         let display =

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -16,6 +16,7 @@ use muvm::cli_options::options;
 use muvm::cpu::{get_fallback_cores, get_performance_cores};
 use muvm::env::{find_muvm_exec, prepare_env_vars};
 use muvm::launch::{launch_or_lock, LaunchResult};
+use muvm::monitor::spawn_monitor;
 use muvm::net::{connect_to_passt, start_passt};
 use muvm::types::MiB;
 use nix::sys::sysinfo::sysinfo;
@@ -434,6 +435,8 @@ fn main() -> Result<()> {
             return Err(err).context("Failed to set the environment variables in the guest");
         }
     }
+
+    spawn_monitor(options.root_server_port, cookie);
 
     {
         // Start and enter the microVM. Unless there is some error while creating the

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -254,7 +254,7 @@ fn main() -> Result<()> {
                 .context("Failed to connect to `passt`")?
                 .into()
         } else {
-            start_passt(options.server_port)
+            start_passt(options.server_port, options.root_server_port)
                 .context("Failed to start `passt`")?
                 .into()
         };
@@ -374,6 +374,10 @@ fn main() -> Result<()> {
     env.insert(
         "MUVM_SERVER_PORT".to_owned(),
         options.server_port.to_string(),
+    );
+    env.insert(
+        "MUVM_ROOT_SERVER_PORT".to_owned(),
+        options.root_server_port.to_string(),
     );
     env.insert("MUVM_SERVER_COOKIE".to_owned(), cookie.to_string());
 

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -13,6 +13,7 @@ pub struct Options {
     pub mem: Option<MiB>,
     pub vram: Option<MiB>,
     pub passt_socket: Option<PathBuf>,
+    pub root_server_port: u32,
     pub server_port: u32,
     pub fex_images: Vec<String>,
     pub direct_x11: bool,
@@ -93,6 +94,12 @@ pub fn options() -> OptionParser<Options> {
         .help("Instead of starting passt, connect to passt socket at PATH")
         .argument("PATH")
         .optional();
+    let root_server_port = long("root-server-port")
+        .short('r')
+        .help("Set the port to be used in root server mode")
+        .argument("ROOT_SERVER_PORT")
+        .fallback(3335)
+        .display_fallback();
     let server_port = long("server-port")
         .short('p')
         .help("Set the port to be used in server mode")
@@ -117,6 +124,7 @@ pub fn options() -> OptionParser<Options> {
         mem,
         vram,
         passt_socket,
+        root_server_port,
         server_port,
         fex_images,
         direct_x11,

--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -62,6 +62,12 @@ fn main() -> Result<()> {
             .spawn()?;
     }
 
+    // Before switching to the user, start another instance of muvm-server to serve
+    // launch requests as root.
+    Command::new("muvm-server")
+        .spawn()
+        .context("Failed to execute `muvm-server` as child process")?;
+
     let run_path = match setup_user(options.username, options.uid, options.gid) {
         Ok(p) => p,
         Err(err) => return Err(err).context("Failed to set up user, bailing out"),

--- a/crates/muvm/src/launch.rs
+++ b/crates/muvm/src/launch.rs
@@ -148,7 +148,7 @@ fn lock_file() -> Result<(Option<File>, Uuid)> {
     Ok((Some(lock_file), cookie))
 }
 
-fn request_launch(
+pub fn request_launch(
     server_port: u32,
     cookie: Uuid,
     command: PathBuf,

--- a/crates/muvm/src/lib.rs
+++ b/crates/muvm/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cli_options;
 pub mod cpu;
 pub mod env;
 pub mod launch;
+pub mod monitor;
 pub mod net;
 pub mod types;
 

--- a/crates/muvm/src/monitor.rs
+++ b/crates/muvm/src/monitor.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::thread;
+use std::time;
+
+use anyhow::Result;
+use log::debug;
+use procfs::{Current, Meminfo};
+use uuid::Uuid;
+
+use crate::launch::request_launch;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum GuestPressure {
+    None,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl From<GuestPressure> for u32 {
+    fn from(pressure: GuestPressure) -> u32 {
+        match pressure {
+            GuestPressure::None => 10,
+            GuestPressure::Low => 1000,
+            GuestPressure::Medium => 2000,
+            GuestPressure::High => 3000,
+            // Same waterlevel as High, but also explicitly requesting
+            // the guest to drop its page cache.
+            GuestPressure::Critical => 3000,
+        }
+    }
+}
+
+pub fn spawn_monitor(server_port: u32, cookie: Uuid) {
+    thread::spawn(move || run(server_port, cookie));
+}
+
+fn set_guest_pressure(server_port: u32, cookie: Uuid, pressure: GuestPressure) -> Result<()> {
+    if pressure == GuestPressure::Critical {
+        debug!("requesting the guest to drop its caches");
+        // This is a fake command that tells muvm-server to write to "/proc/sys/vm/drop_caches"
+        let command = PathBuf::from("/muvmdropcaches");
+        let command_args = vec![];
+        let env = HashMap::new();
+        request_launch(server_port, cookie, command, command_args, env)?;
+    }
+
+    let wsf: u32 = pressure.into();
+    debug!("setting watermark_scale_factor to {wsf}");
+
+    let command = PathBuf::from("/sbin/sysctl");
+    let command_args = vec![format!("vm.watermark_scale_factor={}", wsf)];
+    let env = HashMap::new();
+    request_launch(server_port, cookie, command, command_args, env)
+}
+
+fn run(server_port: u32, cookie: Uuid) {
+    let mut guest_pressure = GuestPressure::None;
+    loop {
+        let meminfo = Meminfo::current().ok();
+        if let Some(meminfo) = meminfo {
+            if let Some(available) = meminfo.mem_available {
+                let avail_ratio = (available * 100) / meminfo.mem_total;
+                debug!(
+                    "avail_ratio={avail_ratio}, avail={available}, total={}",
+                    meminfo.mem_total
+                );
+                let new_pressure = if avail_ratio <= 10 {
+                    GuestPressure::Critical
+                } else if avail_ratio <= 15 {
+                    GuestPressure::High
+                } else if avail_ratio <= 20 {
+                    GuestPressure::Medium
+                } else if avail_ratio <= 25 {
+                    GuestPressure::Low
+                } else {
+                    GuestPressure::None
+                };
+
+                debug!("Pressure at {:?}", new_pressure);
+
+                if new_pressure != guest_pressure {
+                    if let Err(err) = set_guest_pressure(server_port, cookie, new_pressure.clone())
+                    {
+                        println!("Failed to set the new pressure in the guest: {err}");
+                    } else {
+                        guest_pressure = new_pressure;
+                    }
+                }
+            }
+        }
+        thread::sleep(time::Duration::from_millis(500));
+    }
+}

--- a/crates/muvm/src/net.rs
+++ b/crates/muvm/src/net.rs
@@ -14,7 +14,7 @@ where
     Ok(UnixStream::connect(passt_socket_path)?)
 }
 
-pub fn start_passt(server_port: u32) -> Result<UnixStream> {
+pub fn start_passt(server_port: u32, root_server_port: u32) -> Result<UnixStream> {
     // SAFETY: The child process should not inherit the file descriptor of
     // `parent_socket`. There is no documented guarantee of this, but the
     // implementation as of writing atomically sets `SOCK_CLOEXEC`.
@@ -40,7 +40,9 @@ pub fn start_passt(server_port: u32) -> Result<UnixStream> {
     // See https://doc.rust-lang.org/std/io/index.html#io-safety
     let child = Command::new("passt")
         .args(["-q", "-f", "-t"])
-        .arg(format!("{server_port}:{server_port}"))
+        .arg(format!(
+            "{server_port}:{server_port},{root_server_port}:{root_server_port}"
+        ))
         .arg("--fd")
         .arg(format!("{}", child_fd.into_raw_fd()))
         .spawn();

--- a/crates/muvm/src/server/bin/muvm-server.rs
+++ b/crates/muvm/src/server/bin/muvm-server.rs
@@ -1,10 +1,12 @@
 use std::env;
 use std::os::unix::process::ExitStatusExt as _;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use log::error;
 use muvm::server::cli_options::options;
 use muvm::server::worker::{State, Worker};
+use nix::unistd::geteuid;
 use tokio::net::TcpListener;
 use tokio::process::Command;
 use tokio::sync::watch;
@@ -23,19 +25,33 @@ fn main() -> Result<()> {
 async fn tokio_main(cookie: String) -> Result<()> {
     env_logger::init();
 
-    let options = options().run();
     let cookie = Uuid::try_parse(&cookie).context("Couldn't parse cookie as UUID v7")?;
+    let uid: u32 = geteuid().into();
 
-    let listener = TcpListener::bind(format!("0.0.0.0:{}", options.server_port)).await?;
+    let (server_port, command, command_args) = if uid == 0 {
+        let server_port = if let Ok(server_port) = env::var("MUVM_ROOT_SERVER_PORT") {
+            server_port.parse()?
+        } else {
+            3335
+        };
+        (
+            server_port,
+            PathBuf::from("/bin/sleep"),
+            vec!["inf".to_string()],
+        )
+    } else {
+        let options = options().run();
+        (options.server_port, options.command, options.command_args)
+    };
+
+    let listener = TcpListener::bind(format!("0.0.0.0:{}", server_port)).await?;
     let (state_tx, state_rx) = watch::channel(State::new());
 
     let mut worker_handle = tokio::spawn(async move {
         let mut worker = Worker::new(cookie, listener, state_tx);
         worker.run().await;
     });
-    let command_status = Command::new(&options.command)
-        .args(options.command_args)
-        .status();
+    let command_status = Command::new(&command).args(command_args).status();
     tokio::pin!(command_status);
     let mut state_rx = WatchStream::new(state_rx);
 
@@ -63,12 +79,12 @@ async fn tokio_main(cookie: String) -> Result<()> {
                             if let Some(code) = status.code() {
                                 eprintln!(
                                     "{:?} process exited with status code: {code}",
-                                    options.command
+                                    command
                                 );
                             } else {
                                 eprintln!(
                                     "{:?} process terminated by signal: {}",
-                                    options.command,
+                                    command,
                                     status
                                         .signal()
                                         .expect("either one of status code or signal should be set")
@@ -79,7 +95,7 @@ async fn tokio_main(cookie: String) -> Result<()> {
                     Err(err) => {
                         eprintln!(
                             "Failed to execute {:?} as child process: {err}",
-                            options.command
+                            command
                         );
                     },
                 }

--- a/crates/muvm/src/utils/launch.rs
+++ b/crates/muvm/src/utils/launch.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct Launch {
+    pub cookie: Uuid,
     pub command: PathBuf,
     pub command_args: Vec<String>,
     pub env: HashMap<String, String>,


### PR DESCRIPTION
The goal of this PR is to enable muvm to request the guest to adjust its file system cache goals accordingly to the amount of available memory on the host.

The first two commits just set the infrastructure, first by adding some minimal protection to muvm-server, and then spawning a second instance of it as root (we need this to operate in "/proc/sys/vm", but surely will come handy for many other things).

The latter implements the monitor and the ability to request the guest to adjust watermark_scale_factor as needed, or even to drop its pagecache if the situation is critical.