### PR TITLE
muvm: Bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "muvm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muvm"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Sergio Lopez <slp@redhat.com>", "Teoh Han Hui <teohhanhui@gmail.com>"]
 edition = "2021"
 rust-version = "1.77.0"


### PR DESCRIPTION
This is a minor hotfix release to deal with the /etc/hostname issue.