### PR TITLE
Improve VRAM management in the guest

### DIFF
--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -88,6 +88,8 @@ fn main() -> Result<()> {
         } => (cookie, lock_file, command, command_args, env),
     };
 
+    let mut env = prepare_env_vars(env).context("Failed to prepare environment variables")?;
+
     {
         // Set the log level to "off".
         //
@@ -371,7 +373,6 @@ fn main() -> Result<()> {
         muvm_guest_args.push(arg);
     }
 
-    let mut env = prepare_env_vars(env).context("Failed to prepare environment variables")?;
     env.insert(
         "MUVM_SERVER_PORT".to_owned(),
         options.server_port.to_string(),

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -72,12 +72,10 @@ pub fn options() -> OptionParser<Options> {
         .optional();
     let vram = long("vram")
         .help(
-            "The amount of Video RAM, in MiB, that will be available to this microVM.
-            The memory configured for the microVM will not be reserved
-            immediately. Instead, it will be provided as the guest demands
-            it, and will be returned to the host once the guest releases
-            the underlying resources.
-    [default: same as the total amount of RAM in the system]",
+            "The amount of Video RAM, in MiB, that will reported by userspace in this microVM.
+            The userspace drivers will report this amount as heap size
+            to the clients running in the microVM.
+    [default: 50% of total RAM]",
         )
         .argument("VRAM")
         .optional();


### PR DESCRIPTION
    By default, HK sets the heap size to be half the size of the *guest*
    memory. Since commit 167744dc it's also possible to override the heap
    size by setting the HK_SYSMEM environment variable.

    Previously, the vram command line option was acting on the virtio-gpu
    SHM window. This didn't help in most cases because userspace doesn't
    really care nor is aware of it.

    Here, we set the SHM window of virtio-gpu to always be as large as the
    host's RAM, not because we expect VRAM to consume 100% of the RAM (which
    is obviously impossible) but to account for region fragmentation. Then,
    we use HK_SYSMEM to tell userspace the desired heap size (the closest
    thing to VRAM we can aim for), which will be set to either the value
    passed by the user throught the "vram" argument or half the size of the
    *host* RAM.