### PR TITLE
hidpipe: merge hidpipe project into muvm

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -29,7 +29,7 @@ jobs:
             components: rustfmt, clippy
 
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get -y install libclang-dev
+        run: sudo apt-get update && sudo apt-get -y install libclang-dev libudev-dev
 
       - name: Download libkrun.h
         run: sudo curl -o /usr/include/libkrun.h https://raw.githubusercontent.com/containers/libkrun/refs/heads/main/include/libkrun.h

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "input-linux"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e8c4821c88b95582ca69234a1d233f87e44182c42e121f740efb0bec1142e0"
+dependencies = [
+ "input-linux-sys",
+ "nix",
+]
+
+[[package]]
+name = "input-linux-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b91b2248b0eaf0a576ef5e60b7f2107a749e705a876bc0b9fe952ac8d83a724"
+dependencies = [
+ "libc",
+ "nix",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +362,16 @@ name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -393,6 +434,8 @@ dependencies = [
  "bpaf",
  "byteorder",
  "env_logger",
+ "input-linux",
+ "input-linux-sys",
  "krun-sys",
  "log",
  "nix",
@@ -403,6 +446,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "udev",
  "uuid",
 ]
 
@@ -453,6 +497,12 @@ name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "proc-macro2"
@@ -685,6 +735,18 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "udev"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d5c197b95f1769931c89f85c33c407801d1fb7a311113bc0b39ad036f1bd81"
+dependencies = [
+ "io-lifetimes",
+ "libc",
+ "libudev-sys",
+ "pkg-config",
 ]
 
 [[package]]

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -13,6 +13,8 @@ anyhow = { version = "1.0.82", default-features = false, features = ["std"] }
 bpaf = { version = "0.9.11", default-features = false, features = [] }
 byteorder = { version = "1.5.0", default-features = false, features = ["std"] }
 env_logger = { version = "0.11.3", default-features = false, features = ["auto-color", "humantime", "unstable-kv"] }
+input-linux = { version = "0.7.0", default-features = false, features = [] }
+input-linux-sys = { version = "0.9.0", default-features = false, features = [] }
 krun-sys = { path = "../krun-sys", version = "1.9.1", default-features = false, features = [] }
 log = { version = "0.4.21", default-features = false, features = ["kv"] }
 nix = { version = "0.29.0", default-features = false, features = ["user"] }
@@ -23,6 +25,7 @@ serde_json = { version = "1.0.117", default-features = false, features = ["std"]
 tempfile = { version = "3.10.1", default-features = false, features = [] }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util", "macros", "net", "process", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1.15", default-features = false, features = ["net", "sync"] }
+udev = { version = "0.9.0", default-features = false, features = [] }
 uuid = { version = "1.10.0", default-features = false, features = ["serde", "std", "v7"] }
 
 [features]
@@ -36,6 +39,10 @@ path = "src/bin/muvm.rs"
 [[bin]]
 name = "muvm-guest"
 path = "src/guest/bin/muvm-guest.rs"
+
+[[bin]]
+name = "muvm-hidpipe"
+path = "src/hidpipe/bin/muvm-hidpipe.rs"
 
 [[bin]]
 name = "muvm-server"

--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -14,7 +14,6 @@ use muvm::guest::sommelier::exec_sommelier;
 use muvm::guest::user::setup_user;
 #[cfg(feature = "x11bridge")]
 use muvm::guest::x11::setup_x11_forwarding;
-use muvm::utils::env::find_in_path;
 use rustix::process::{getrlimit, setrlimit, Resource};
 
 fn main() -> Result<()> {
@@ -57,11 +56,10 @@ fn main() -> Result<()> {
 
     configure_network()?;
 
-    if let Some(hidpipe_client_path) = find_in_path("hidpipe-client")? {
-        Command::new(hidpipe_client_path)
-            .arg(format!("{}", options.uid))
-            .spawn()?;
-    }
+    Command::new("muvm-hidpipe")
+        .arg(format!("{}", options.uid))
+        .spawn()
+        .context("Failed to execute `muvm-hidpipe` as child process")?;
 
     // Before switching to the user, start another instance of muvm-server to serve
     // launch requests as root.

--- a/crates/muvm/src/hidpipe/bin/muvm-hidpipe.rs
+++ b/crates/muvm/src/hidpipe/bin/muvm-hidpipe.rs
@@ -1,0 +1,314 @@
+use input_linux::bitmask::BitmaskTrait;
+use input_linux::{
+    AbsoluteAxis, AbsoluteInfo, Bitmask, EventKind, ForceFeedbackKind, InputProperty, Key, LedKind,
+    MiscKind, RelativeAxis, SoundKind, SwitchKind, UInputHandle, UInputKind,
+};
+use input_linux_sys::{
+    ff_effect, ff_replay, ff_trigger, input_absinfo, input_id, uinput_abs_setup, uinput_ff_erase,
+    uinput_ff_upload, uinput_setup,
+};
+use muvm::hidpipe_common::{
+    empty_input_event, struct_to_socket, AddDevice, ClientHello, FFErase, FFUpload, InputEvent,
+    MessageType, RemoveDevice, ServerHello,
+};
+use nix::errno::Errno;
+use nix::libc::{c_char, O_NONBLOCK};
+use nix::sys::epoll::{Epoll, EpollCreateFlags, EpollEvent, EpollFlags, EpollTimeout};
+use nix::sys::socket::{connect, socket, AddressFamily, SockFlag, SockType, VsockAddr};
+use std::collections::HashMap;
+use std::env;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{chown, OpenOptionsExt};
+use std::os::unix::net::UnixStream;
+use std::{mem, slice};
+
+const ADD_DEVICE: u32 = MessageType::AddDevice as u32;
+const REMOVE_DEVICE: u32 = MessageType::RemoveDevice as u32;
+const INPUT_EVENT: u32 = MessageType::InputEvent as u32;
+const FF_UPLOAD: u32 = MessageType::FFUpload as u32;
+const FF_ERASE: u32 = MessageType::FFErase as u32;
+
+fn bitmask_from_slice<T, A>(s: &T::Array) -> Bitmask<T>
+where
+    A: AsRef<[u8]>,
+    T: BitmaskTrait<Array = A>,
+{
+    let mut bm = Bitmask::<T>::default();
+    bm.copy_from_slice(s.as_ref());
+    bm
+}
+
+fn init_uinput(sock: &mut UnixStream, user_id: u32) -> (u64, UInputHandle<File>) {
+    let mut add_dev_data = [0u8; mem::size_of::<AddDevice>()];
+    sock.read_exact(&mut add_dev_data).unwrap();
+    let add_dev = unsafe {
+        (add_dev_data.as_ptr() as *const AddDevice)
+            .as_ref()
+            .unwrap()
+    };
+    let uinput = UInputHandle::new(
+        File::options()
+            .read(true)
+            .write(true)
+            .custom_flags(O_NONBLOCK)
+            .open("/dev/uinput")
+            .unwrap(),
+    );
+    for evbit in bitmask_from_slice::<EventKind, _>(&add_dev.evbits).iter() {
+        uinput.set_evbit(evbit).unwrap();
+    }
+    for keybit in bitmask_from_slice::<Key, _>(&add_dev.keybits).iter() {
+        uinput.set_keybit(keybit).unwrap();
+    }
+    for relbit in bitmask_from_slice::<RelativeAxis, _>(&add_dev.relbits).iter() {
+        uinput.set_relbit(relbit).unwrap();
+    }
+    for absbit in bitmask_from_slice::<AbsoluteAxis, _>(&add_dev.absbits).iter() {
+        uinput.set_absbit(absbit).unwrap();
+        let mut absinfo_data = [0u8; mem::size_of::<AbsoluteInfo>()];
+        sock.read_exact(&mut absinfo_data).unwrap();
+        let abs_info = unsafe {
+            (absinfo_data.as_ptr() as *const AbsoluteInfo)
+                .as_ref()
+                .unwrap()
+        };
+        uinput
+            .abs_setup(&uinput_abs_setup {
+                code: absbit as u16,
+                absinfo: input_absinfo {
+                    value: abs_info.value,
+                    minimum: abs_info.minimum,
+                    maximum: abs_info.maximum,
+                    fuzz: abs_info.fuzz,
+                    flat: abs_info.flat,
+                    resolution: abs_info.resolution,
+                },
+            })
+            .unwrap();
+    }
+    for mscbit in bitmask_from_slice::<MiscKind, _>(&add_dev.mscbits).iter() {
+        uinput.set_mscbit(mscbit).unwrap();
+    }
+    for ledbit in bitmask_from_slice::<LedKind, _>(&add_dev.ledbits).iter() {
+        uinput.set_ledbit(ledbit).unwrap();
+    }
+    for sndbit in bitmask_from_slice::<SoundKind, _>(&add_dev.sndbits).iter() {
+        uinput.set_sndbit(sndbit).unwrap();
+    }
+    for swbit in bitmask_from_slice::<SwitchKind, _>(&add_dev.swbits).iter() {
+        uinput.set_swbit(swbit).unwrap();
+    }
+    for propbit in bitmask_from_slice::<InputProperty, _>(&add_dev.propbits).iter() {
+        uinput.set_propbit(propbit).unwrap();
+    }
+    for ffbit in bitmask_from_slice::<ForceFeedbackKind, _>(&add_dev.ffbits).iter() {
+        uinput.set_ffbit(ffbit).unwrap();
+    }
+    uinput
+        .dev_setup(&uinput_setup {
+            id: input_id {
+                bustype: add_dev.input_id.bustype,
+                vendor: add_dev.input_id.vendor,
+                product: add_dev.input_id.product,
+                version: add_dev.input_id.version,
+            },
+            name: add_dev.name.map(|c| c as c_char),
+            ff_effects_max: add_dev.ff_effects,
+        })
+        .unwrap();
+    uinput.dev_create().unwrap();
+    chown(uinput.evdev_path().unwrap(), Some(user_id), Some(0)).unwrap();
+    (add_dev.id, uinput)
+}
+
+fn ff_effect_empty() -> ff_effect {
+    ff_effect {
+        type_: 0,
+        id: 0,
+        direction: 0,
+        trigger: ff_trigger {
+            button: 0,
+            interval: 0,
+        },
+        replay: ff_replay {
+            length: 0,
+            delay: 0,
+        },
+        u: [0; 4],
+    }
+}
+
+fn main() {
+    let user_id = env::args().nth(1).unwrap().parse::<u32>().unwrap();
+    let sock_fd = socket(
+        AddressFamily::Vsock,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+    connect(sock_fd.as_raw_fd(), &VsockAddr::new(2, 3334)).unwrap();
+    let mut sock = UnixStream::from(sock_fd);
+    let c_hello = ClientHello { version: 0 };
+    let c_hello_data = unsafe {
+        slice::from_raw_parts(
+            &c_hello as *const ClientHello as *const u8,
+            mem::size_of::<ClientHello>(),
+        )
+    };
+    sock.write_all(c_hello_data).unwrap();
+    let mut s_hello_data = [0u8; mem::size_of::<ServerHello>()];
+    sock.read_exact(&mut s_hello_data).unwrap();
+    let epoll = Epoll::new(EpollCreateFlags::empty()).unwrap();
+    epoll
+        .add(
+            &sock,
+            EpollEvent::new(EpollFlags::EPOLLIN, sock.as_raw_fd() as u64),
+        )
+        .unwrap();
+    let mut inputs_by_id = HashMap::new();
+    let mut fd_to_id = HashMap::new();
+    let mut ff_uploads = HashMap::<u32, uinput_ff_upload>::new();
+    let mut ff_erases = HashMap::<u32, uinput_ff_erase>::new();
+    loop {
+        let mut evts = [EpollEvent::empty()];
+        match epoll.wait(&mut evts, EpollTimeout::NONE) {
+            Err(Errno::EINTR) | Ok(0) => {
+                continue;
+            },
+            Ok(_) => {},
+            e => {
+                e.unwrap();
+            },
+        }
+        let fd = evts[0].data();
+        if fd == sock.as_raw_fd() as u64 {
+            let mut cmd_data = [0u8; mem::size_of::<MessageType>()];
+            sock.read_exact(&mut cmd_data).unwrap();
+            match u32::from_ne_bytes(cmd_data) {
+                ADD_DEVICE => {
+                    let (id, uinput) = init_uinput(&mut sock, user_id);
+                    let raw = uinput.as_inner().as_raw_fd() as u64;
+                    epoll
+                        .add(uinput.as_inner(), EpollEvent::new(EpollFlags::EPOLLIN, raw))
+                        .unwrap();
+                    inputs_by_id.insert(id, uinput);
+                    fd_to_id.insert(raw, id);
+                },
+                REMOVE_DEVICE => {
+                    let mut remove_dev_data = [0u8; mem::size_of::<RemoveDevice>()];
+                    sock.read_exact(&mut remove_dev_data).unwrap();
+                    let remove_dev = unsafe {
+                        (remove_dev_data.as_ptr() as *const RemoveDevice)
+                            .as_ref()
+                            .unwrap()
+                    };
+                    if let Some(uinput) = inputs_by_id.remove(&remove_dev.id) {
+                        let raw = uinput.as_inner().as_raw_fd() as u64;
+                        fd_to_id.remove(&raw);
+                        epoll.delete(uinput.as_inner()).unwrap();
+                        uinput.dev_destroy().unwrap();
+                    }
+                },
+                INPUT_EVENT => {
+                    let mut event_data = [0u8; mem::size_of::<InputEvent>()];
+                    sock.read_exact(&mut event_data).unwrap();
+                    let event =
+                        unsafe { (event_data.as_ptr() as *const InputEvent).as_ref().unwrap() };
+                    let dev = inputs_by_id.get(&event.id);
+                    if dev.is_none() {
+                        continue;
+                    }
+                    dev.unwrap().write(&[event.to_input_event()]).unwrap();
+                },
+                FF_UPLOAD => {
+                    let mut upload_data = [0u8; mem::size_of::<FFUpload>()];
+                    sock.read_exact(&mut upload_data).unwrap();
+                    let upload =
+                        unsafe { (upload_data.as_ptr() as *const FFUpload).as_ref().unwrap() };
+                    let dev = inputs_by_id.get(&upload.id);
+                    if dev.is_none() {
+                        continue;
+                    }
+                    if let Some(mut ff_up) = ff_uploads.remove(&upload.request_id) {
+                        ff_up.effect = upload.effect;
+                        dev.unwrap().ff_upload_end(&ff_up).unwrap();
+                    }
+                },
+                FF_ERASE => {
+                    let mut erase_resp_data = [0u8; mem::size_of::<FFErase>()];
+                    sock.read_exact(&mut erase_resp_data).unwrap();
+                    let erase = unsafe {
+                        (erase_resp_data.as_ptr() as *const FFErase)
+                            .as_ref()
+                            .unwrap()
+                    };
+                    let dev = inputs_by_id.get(&erase.id);
+                    if dev.is_none() {
+                        continue;
+                    }
+                    if let Some(ff_ers) = ff_erases.remove(&erase.request_id) {
+                        dev.unwrap().ff_erase_end(&ff_ers).unwrap();
+                    }
+                },
+                m => panic!("Unknown message {}", m),
+            }
+        } else if let Some(id) = fd_to_id.get(&fd) {
+            let uinput = inputs_by_id.get(id).unwrap();
+            let mut evts = [empty_input_event()];
+            while let Ok(count) = uinput.read(&mut evts) {
+                if count == 0 {
+                    break;
+                }
+                if evts[0].type_ == EventKind::UInput as u16 {
+                    if evts[0].code == UInputKind::ForceFeedbackUpload as u16 {
+                        let mut upload = uinput_ff_upload {
+                            request_id: evts[0].value as u32,
+                            retval: 0,
+                            effect: ff_effect_empty(),
+                            old: ff_effect_empty(),
+                        };
+                        uinput.ff_upload_begin(&mut upload).unwrap();
+                        struct_to_socket(&mut sock, &MessageType::FFUpload).unwrap();
+                        struct_to_socket(
+                            &mut sock,
+                            &FFUpload {
+                                id: *id,
+                                request_id: upload.request_id,
+                                effect: upload.effect,
+                            },
+                        )
+                        .unwrap();
+                        ff_uploads.insert(upload.request_id, upload);
+                    } else if evts[0].code == UInputKind::ForceFeedbackErase as u16 {
+                        let mut erase = uinput_ff_erase {
+                            request_id: evts[0].value as u32,
+                            retval: 0,
+                            effect_id: 0,
+                        };
+                        uinput.ff_erase_begin(&mut erase).unwrap();
+                        struct_to_socket(&mut sock, &MessageType::FFErase).unwrap();
+                        struct_to_socket(
+                            &mut sock,
+                            &FFErase {
+                                id: *id,
+                                request_id: erase.request_id,
+                                effect_id: erase.effect_id,
+                            },
+                        )
+                        .unwrap();
+                        ff_erases.insert(erase.request_id, erase);
+                    } else {
+                        eprintln!("Ignoring unknown uinput event: {:?}", evts[0]);
+                    }
+                } else {
+                    let ev = InputEvent::new(*id, evts[0]);
+                    struct_to_socket(&mut sock, &MessageType::InputEvent).unwrap();
+                    struct_to_socket(&mut sock, &ev).unwrap();
+                }
+            }
+        }
+    }
+}

--- a/crates/muvm/src/hidpipe_common.rs
+++ b/crates/muvm/src/hidpipe_common.rs
@@ -1,0 +1,126 @@
+use input_linux::sys::{ff_effect, input_event, timeval};
+use input_linux::{
+    bitmask::BitmaskTrait, AbsoluteAxis, EventKind, ForceFeedbackKind, InputId, InputProperty, Key,
+    LedKind, MiscKind, RelativeAxis, SoundKind, SwitchKind,
+};
+use std::io::{Result, Write};
+use std::os::unix::net::UnixStream;
+use std::{mem, slice};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct ClientHello {
+    pub version: u32,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct ServerHello {
+    pub version: u32,
+}
+
+#[repr(u32)]
+#[derive(Debug)]
+pub enum MessageType {
+    AddDevice,
+    RemoveDevice,
+    InputEvent,
+    FFUpload,
+    FFErase,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct FFUpload {
+    pub id: u64,
+    pub request_id: u32,
+    pub effect: ff_effect,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct FFErase {
+    pub id: u64,
+    pub request_id: u32,
+    pub effect_id: u32,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct AddDevice {
+    pub id: u64,
+    pub evbits: <EventKind as BitmaskTrait>::Array,
+    pub keybits: <Key as BitmaskTrait>::Array,
+    pub relbits: <RelativeAxis as BitmaskTrait>::Array,
+    pub absbits: <AbsoluteAxis as BitmaskTrait>::Array,
+    pub mscbits: <MiscKind as BitmaskTrait>::Array,
+    pub ledbits: <LedKind as BitmaskTrait>::Array,
+    pub sndbits: <SoundKind as BitmaskTrait>::Array,
+    pub swbits: <SwitchKind as BitmaskTrait>::Array,
+    pub propbits: <InputProperty as BitmaskTrait>::Array,
+    pub ffbits: <ForceFeedbackKind as BitmaskTrait>::Array,
+    pub input_id: InputId,
+    pub ff_effects: u32,
+    pub name: [u8; 80],
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct RemoveDevice {
+    pub id: u64,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct InputEvent {
+    pub time_sec: i64,
+    pub time_usec: i64,
+    pub id: u64,
+    pub value: i32,
+    pub ty: u16,
+    pub code: u16,
+}
+
+impl InputEvent {
+    pub fn new(id: u64, e: input_event) -> InputEvent {
+        InputEvent {
+            id,
+            ty: e.type_,
+            code: e.code,
+            value: e.value,
+            time_sec: e.time.tv_sec,
+            time_usec: e.time.tv_usec,
+        }
+    }
+    pub fn to_input_event(&self) -> input_event {
+        input_event {
+            time: timeval {
+                tv_sec: self.time_sec,
+                tv_usec: self.time_usec,
+            },
+            type_: self.ty,
+            code: self.code,
+            value: self.value,
+        }
+    }
+}
+
+pub fn empty_input_event() -> input_event {
+    input_event {
+        time: timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
+        type_: 0,
+        code: 0,
+        value: 0,
+    }
+}
+
+pub fn struct_to_socket<T>(socket: &mut UnixStream, data: &T) -> Result<()> {
+    let size = mem::size_of::<T>();
+    // SAFETY:
+    // We are taking a ref, so it is valid for reads, properly aligned, and nobody can write to it
+    let v = unsafe { slice::from_raw_parts(data as *const T as *const u8, size) };
+    socket.write_all(v)
+}

--- a/crates/muvm/src/hidpipe_server.rs
+++ b/crates/muvm/src/hidpipe_server.rs
@@ -1,0 +1,529 @@
+use anyhow::Context;
+use input_linux::{evdev::EvdevHandle, AbsoluteAxis, EventKind, InputProperty, Key, MiscKind};
+use log::{debug, error};
+use nix::errno::Errno;
+use nix::sys::epoll::{Epoll, EpollCreateFlags, EpollEvent, EpollFlags, EpollTimeout};
+use std::collections::hash_map;
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
+use std::io::{ErrorKind, Read, Result};
+use std::net::Shutdown;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::thread;
+use std::{
+    fs::{self, File},
+    mem,
+};
+use udev::{EventType, MonitorBuilder};
+
+use crate::hidpipe_common::{
+    empty_input_event, struct_to_socket, AddDevice, ClientHello, FFErase, FFUpload, InputEvent,
+    MessageType, RemoveDevice, ServerHello,
+};
+
+fn is_joystick<F: AsRawFd>(evdev: &EvdevHandle<F>) -> Result<bool> {
+    let props = evdev.device_properties()?;
+    let no = Ok(false);
+    if props.get(InputProperty::Accelerometer)
+        || props.get(InputProperty::PointingStick)
+        || props.get(InputProperty::TopButtonPad)
+        || props.get(InputProperty::ButtonPad)
+        || props.get(InputProperty::SemiMultiTouch)
+    {
+        return no;
+    }
+    let events = evdev.event_bits()?;
+    if !events.get(EventKind::Absolute) {
+        return no;
+    }
+    let axes = evdev.absolute_mask()?;
+    if !axes.get(AbsoluteAxis::X) || !axes.get(AbsoluteAxis::Y) {
+        return no;
+    }
+    let keys = evdev.key_mask()?;
+    Ok(keys.get(Key::ButtonTrigger)
+        || keys.get(Key::ButtonSouth)
+        || keys.get(Key::Button1)
+        || axes.get(AbsoluteAxis::RX)
+        || axes.get(AbsoluteAxis::RY)
+        || axes.get(AbsoluteAxis::Throttle)
+        || axes.get(AbsoluteAxis::Rudder)
+        || axes.get(AbsoluteAxis::Wheel)
+        || axes.get(AbsoluteAxis::Gas)
+        || axes.get(AbsoluteAxis::Brake))
+}
+
+fn send_add_device<F: AsRawFd>(evdev: &EvdevHandle<F>, client: &mut Client) -> Result<()> {
+    let abs = evdev.absolute_bits()?;
+    let evbits = *evdev.event_bits()?.data();
+    let keybits = *evdev.key_bits()?.data();
+    let relbits = *evdev.relative_bits()?.data();
+    let absbits = *abs.data();
+    let mut mscbits = evdev.misc_bits()?;
+    mscbits.remove(MiscKind::Scancode);
+    let mscbits = *mscbits.data();
+    let ledbits = *evdev.led_bits()?.data();
+    let sndbits = *evdev.sound_bits()?.data();
+    let swbits = *evdev.switch_bits()?.data();
+    let propbits = *evdev.device_properties()?.data();
+    let ffbits = *evdev.force_feedback_bits()?.data();
+    let input_id = evdev.device_id()?;
+    let ff_effects = evdev.effects_count()? as u32;
+    let id = evdev.as_raw_fd() as u64;
+    let mut name = [0; 80];
+    evdev.device_name_buf(&mut name)?;
+    client.write(&MessageType::AddDevice)?;
+    client.write(&AddDevice {
+        evbits,
+        keybits,
+        relbits,
+        absbits,
+        mscbits,
+        ledbits,
+        id,
+        sndbits,
+        swbits,
+        propbits,
+        input_id,
+        name,
+        ff_effects,
+        ffbits,
+    })?;
+    for bit in abs.iter() {
+        let info = evdev.absolute_info(bit)?;
+        client.write(&info)?;
+    }
+    Ok(())
+}
+
+struct EvdevContainer {
+    fds_to_devs: HashMap<u64, EvdevHandle<File>>,
+    names_to_fds: HashMap<String, u64>,
+}
+
+fn insert_entry<K, V>(entry: hash_map::Entry<K, V>, v: V) -> &V {
+    match entry {
+        hash_map::Entry::Vacant(e) => e.insert(v),
+        hash_map::Entry::Occupied(mut e) => {
+            e.insert(v);
+            e.into_mut()
+        },
+    }
+}
+
+impl EvdevContainer {
+    fn new() -> EvdevContainer {
+        EvdevContainer {
+            fds_to_devs: HashMap::new(),
+            names_to_fds: HashMap::new(),
+        }
+    }
+    fn check_and_add(
+        &mut self,
+        dev_name: &OsStr,
+        file_name: &OsStr,
+        epoll: &Epoll,
+    ) -> Result<Option<&EvdevHandle<File>>> {
+        let dev_name = dev_name.to_string_lossy();
+        if !dev_name.starts_with("event") {
+            return Ok(None);
+        }
+        let file = File::options()
+            .read(true)
+            .write(true)
+            .custom_flags(nix::libc::O_NONBLOCK)
+            .open(file_name)?;
+        let evdev = EvdevHandle::new(file);
+        if is_joystick(&evdev)? {
+            let raw = evdev.as_raw_fd() as u64;
+            self.names_to_fds.insert(dev_name.into_owned(), raw);
+            epoll
+                .add(evdev.as_inner(), EpollEvent::new(EpollFlags::EPOLLIN, raw))
+                .unwrap();
+            Ok(Some(insert_entry(self.fds_to_devs.entry(raw), evdev)))
+        } else {
+            Ok(None)
+        }
+    }
+    fn remove(&mut self, dev_name: &OsStr, epoll: &Epoll) -> Option<u64> {
+        if let Some(id) = self
+            .names_to_fds
+            .remove(dev_name.to_string_lossy().as_ref())
+        {
+            let evdev = self.fds_to_devs.remove(&id).unwrap();
+            epoll.delete(evdev.as_inner()).unwrap();
+            Some(id)
+        } else {
+            None
+        }
+    }
+    fn get(&self, id: u64) -> Option<&EvdevHandle<File>> {
+        self.fds_to_devs.get(&id)
+    }
+    fn iter(&self) -> impl Iterator<Item = &EvdevHandle<File>> {
+        self.fds_to_devs.values()
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum WaitingFor {
+    Hello,
+    Header,
+    InputEvent,
+    FFUpload,
+    FFErase,
+}
+
+struct Client {
+    socket: UnixStream,
+    buf: Vec<u8>,
+    filled: usize,
+    waiting_for: WaitingFor,
+}
+
+enum ReadReply {
+    Data(Vec<u8>),
+    NotReady,
+    Hangup,
+}
+
+impl Client {
+    fn new(socket: UnixStream) -> Client {
+        Client {
+            socket,
+            waiting_for: WaitingFor::Hello,
+            buf: Vec::new(),
+            filled: 0,
+        }
+    }
+    fn read(&mut self, size: usize) -> Result<ReadReply> {
+        if self.buf.is_empty() {
+            self.buf.resize(size, 0);
+        } else if self.buf.len() != size {
+            panic!("api misuse");
+        }
+        let read = self.socket.read(&mut self.buf[self.filled..])?;
+        if read == 0 {
+            return Ok(ReadReply::Hangup);
+        }
+        self.filled += read;
+        Ok(if self.filled == size {
+            let mut ret = Vec::new();
+            mem::swap(&mut self.buf, &mut ret);
+            self.filled = 0;
+            ReadReply::Data(ret)
+        } else {
+            ReadReply::NotReady
+        })
+    }
+    fn write<T>(&mut self, data: &T) -> Result<()> {
+        struct_to_socket(&mut self.socket, data)
+    }
+}
+
+fn recv_from_client(
+    clients: &mut HashMap<u64, Client>,
+    epoll: &Epoll,
+    fd: u64,
+    size: usize,
+) -> Option<Vec<u8>> {
+    let client = clients.get_mut(&fd).unwrap();
+    match client.read(size) {
+        Ok(ReadReply::NotReady) => None,
+        Ok(ReadReply::Data(data)) => Some(data),
+        Ok(ReadReply::Hangup) => {
+            epoll.delete(&client.socket).unwrap();
+            clients.remove(&fd);
+            None
+        },
+        Err(e) => {
+            error!("Client {} disconnected with error: {:?}", fd, e);
+            epoll.delete(&client.socket).unwrap();
+            clients.remove(&fd);
+            None
+        },
+    }
+}
+
+fn hangup_on_error_bcast<F>(clients: &mut HashMap<u64, Client>, epoll: &Epoll, mut f: F)
+where
+    F: FnMut(&mut Client) -> Result<()>,
+{
+    clients.retain(|k, v| {
+        if v.waiting_for == WaitingFor::Hello {
+            return true;
+        }
+        let res = f(v);
+        if res.is_err() {
+            error!(
+                "Client {} disconnected with error: {:?}",
+                *k,
+                res.unwrap_err()
+            );
+            epoll.delete(&v.socket).unwrap();
+            false
+        } else {
+            true
+        }
+    });
+}
+
+fn hangup_on_error<F>(clients: &mut HashMap<u64, Client>, epoll: &Epoll, fd: u64, f: F)
+where
+    F: FnOnce(&mut Client) -> Result<()>,
+{
+    let client = clients.get_mut(&fd).unwrap();
+    let res = f(client);
+    if res.is_err() {
+        error!(
+            "Client {} disconnected with error: {:?}",
+            fd,
+            res.unwrap_err()
+        );
+        epoll.delete(&client.socket).unwrap();
+        clients.remove(&fd);
+    }
+}
+
+pub fn spawn_hidpipe_server(socket_path: PathBuf) -> anyhow::Result<()> {
+    let mut evdevs = EvdevContainer::new();
+    let epoll = Epoll::new(EpollCreateFlags::empty()).context("Failed to create epoll object")?;
+    for dir_ent in
+        fs::read_dir("/dev/input/").context("Failed to read \"/dev/input/\" directory")?
+    {
+        let dir_ent = dir_ent.context("Failed to read directory entry")?;
+        if dir_ent
+            .file_type()
+            .context("Failed to obtain file type")?
+            .is_dir()
+        {
+            continue;
+        }
+        let name = dir_ent.file_name();
+        let res = evdevs.check_and_add(&name, dir_ent.path().as_os_str(), &epoll);
+        match res {
+            Ok(Some(_)) => debug!("{} is a joystick", name.to_string_lossy()),
+            Ok(None) => debug!("{} is not a joystick", name.to_string_lossy()),
+            Err(e) if e.kind() == ErrorKind::PermissionDenied => debug!(
+                "Unable to access {}, this is most likely fine",
+                name.to_string_lossy()
+            ),
+            Err(e) => debug!(
+                "Unable to determine if {} is a joystick, error: {:?}",
+                name.to_string_lossy(),
+                e
+            ),
+        }
+    }
+    _ = fs::remove_file(&socket_path);
+    let listen_sock =
+        UnixListener::bind(socket_path).context("Failed to create socket for hidpipe")?;
+    epoll
+        .add(
+            &listen_sock,
+            EpollEvent::new(EpollFlags::EPOLLIN, listen_sock.as_raw_fd() as u64),
+        )
+        .unwrap();
+
+    thread::spawn(move || run(evdevs, listen_sock, epoll));
+    Ok(())
+}
+
+fn run(mut evdevs: EvdevContainer, listen_sock: UnixListener, epoll: Epoll) {
+    let udev_socket = MonitorBuilder::new()
+        .unwrap()
+        .match_subsystem("input")
+        .unwrap()
+        .listen()
+        .unwrap();
+    epoll
+        .add(
+            &udev_socket,
+            EpollEvent::new(EpollFlags::EPOLLIN, udev_socket.as_raw_fd() as u64),
+        )
+        .unwrap();
+
+    let mut clients = HashMap::new();
+    let mut seen_effect = HashSet::new();
+
+    loop {
+        let mut evts = [EpollEvent::empty()];
+        match epoll.wait(&mut evts, EpollTimeout::NONE) {
+            Err(Errno::EINTR) | Ok(0) => {
+                continue;
+            },
+            Ok(_) => {},
+            e => {
+                e.unwrap();
+            },
+        }
+        let fd = evts[0].data();
+        if fd == udev_socket.as_raw_fd() as u64 {
+            for event in udev_socket.iter() {
+                match event.event_type() {
+                    EventType::Remove => {
+                        if let Some(id) = evdevs.remove(event.sysname(), &epoll) {
+                            hangup_on_error_bcast(&mut clients, &epoll, |client| {
+                                client.write(&MessageType::RemoveDevice)?;
+                                client.write(&RemoveDevice { id })
+                            });
+                        }
+                    },
+                    EventType::Add => {
+                        let name = event.sysname();
+                        let node = event.devnode();
+                        if node.is_none() {
+                            continue;
+                        }
+                        let res = evdevs.check_and_add(name, node.unwrap().as_os_str(), &epoll);
+                        match res {
+                            Err(e) => {
+                                error!(
+                                    "Unable to determine if {} is a joystick, error: {:?}",
+                                    name.to_string_lossy(),
+                                    e
+                                );
+                            },
+                            Ok(None) => {},
+                            Ok(Some(dev)) => {
+                                hangup_on_error_bcast(&mut clients, &epoll, |client| {
+                                    send_add_device(dev, client)
+                                });
+                            },
+                        }
+                    },
+                    _ => {},
+                }
+            }
+        } else if fd == listen_sock.as_raw_fd() as u64 {
+            let res = listen_sock.accept();
+            if res.is_err() {
+                error!(
+                    "Failed to accept a connection, error: {:?}",
+                    res.unwrap_err()
+                );
+                continue;
+            }
+            let stream = res.unwrap().0;
+            stream.set_nonblocking(true).unwrap();
+            let raw = stream.as_raw_fd() as u64;
+            epoll
+                .add(&stream, EpollEvent::new(EpollFlags::EPOLLIN, raw))
+                .unwrap();
+            let client = Client::new(stream);
+            clients.insert(raw, client);
+        } else if let Some(client) = clients.get(&fd) {
+            if client.waiting_for == WaitingFor::Hello {
+                let data =
+                    recv_from_client(&mut clients, &epoll, fd, mem::size_of::<ClientHello>());
+                if data.is_none() {
+                    continue;
+                }
+                hangup_on_error(&mut clients, &epoll, fd, |client| {
+                    client.write(&ServerHello { version: 0 })?;
+                    for dev in evdevs.iter() {
+                        send_add_device(dev, client)?;
+                    }
+                    client.waiting_for = WaitingFor::Header;
+                    Ok(())
+                });
+            } else if client.waiting_for == WaitingFor::Header {
+                let data =
+                    recv_from_client(&mut clients, &epoll, fd, mem::size_of::<MessageType>());
+                if data.is_none() {
+                    continue;
+                }
+                let data = data.unwrap();
+                let msg_type = u32::from_ne_bytes(data.try_into().unwrap());
+                let client = clients.get_mut(&fd).unwrap();
+                if msg_type == MessageType::InputEvent as u32 {
+                    client.waiting_for = WaitingFor::InputEvent;
+                } else if msg_type == MessageType::FFUpload as u32 {
+                    client.waiting_for = WaitingFor::FFUpload;
+                } else if msg_type == MessageType::FFErase as u32 {
+                    client.waiting_for = WaitingFor::FFErase;
+                } else {
+                    error!("Unknown message {} from client {}", msg_type, fd);
+                    client.socket.shutdown(Shutdown::Both).unwrap();
+                    continue;
+                }
+            } else if client.waiting_for == WaitingFor::InputEvent {
+                let data = recv_from_client(&mut clients, &epoll, fd, mem::size_of::<InputEvent>());
+                if data.is_none() {
+                    continue;
+                }
+                let data = data.unwrap();
+                let event = unsafe { (data.as_ptr() as *const InputEvent).as_ref().unwrap() };
+                let evdev = evdevs.get(event.id);
+                if evdev.is_none() {
+                    error!("Client {} sent input to unknown device {}", fd, event.id);
+                    continue;
+                }
+                evdev.unwrap().write(&[event.to_input_event()]).unwrap();
+                clients.get_mut(&fd).unwrap().waiting_for = WaitingFor::Header;
+            } else if client.waiting_for == WaitingFor::FFUpload {
+                let data = recv_from_client(&mut clients, &epoll, fd, mem::size_of::<FFUpload>());
+                if data.is_none() {
+                    continue;
+                }
+                let mut data = data.unwrap();
+                let upload = unsafe { (data.as_mut_ptr() as *mut FFUpload).as_mut().unwrap() };
+                let evdev = evdevs.get(upload.id);
+                if evdev.is_none() {
+                    error!("Client {} sent input to unknown device {}", fd, upload.id);
+                    continue;
+                }
+                if seen_effect.insert((upload.id, upload.effect.id)) {
+                    upload.effect.id = -1;
+                }
+                evdev
+                    .unwrap()
+                    .send_force_feedback(&mut upload.effect)
+                    .unwrap();
+                hangup_on_error(&mut clients, &epoll, fd, |client| {
+                    client.waiting_for = WaitingFor::Header;
+                    client.write(&MessageType::FFUpload)?;
+                    client.write(upload)
+                });
+            } else if client.waiting_for == WaitingFor::FFErase {
+                let data = recv_from_client(&mut clients, &epoll, fd, mem::size_of::<FFErase>());
+                if data.is_none() {
+                    continue;
+                }
+                let mut data = data.unwrap();
+                let erase = unsafe { (data.as_mut_ptr() as *const FFErase).as_ref().unwrap() };
+                let evdev = evdevs.get(erase.id);
+                if evdev.is_none() {
+                    error!("Client {} sent input to unknown device {}", fd, erase.id);
+                    continue;
+                }
+                let effect_id = erase.effect_id as i16;
+                seen_effect.remove(&(erase.id, effect_id));
+                evdev.unwrap().erase_force_feedback(effect_id).unwrap();
+                hangup_on_error(&mut clients, &epoll, fd, |client| {
+                    client.waiting_for = WaitingFor::Header;
+                    client.write(&MessageType::FFErase)?;
+                    client.write(erase)
+                });
+            }
+        } else if let Some(evdev) = evdevs.get(fd) {
+            let mut evts = [empty_input_event()];
+            while let Ok(count) = evdev.read(&mut evts) {
+                if count == 0 {
+                    break;
+                }
+                if evts[0].type_ == EventKind::ForceFeedback as u16 {
+                    continue;
+                }
+                let ev = InputEvent::new(fd, evts[0]);
+                hangup_on_error_bcast(&mut clients, &epoll, |client| {
+                    client.write(&MessageType::InputEvent)?;
+                    client.write(&ev)
+                });
+            }
+        }
+    }
+}

--- a/crates/muvm/src/lib.rs
+++ b/crates/muvm/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod cli_options;
 pub mod cpu;
 pub mod env;
+pub mod hidpipe_common;
+pub mod hidpipe_server;
 pub mod launch;
 pub mod monitor;
 pub mod net;


### PR DESCRIPTION
Merge hidpipe project into muvm, with hidpipe-server operating as a thread inside the main muvm binary, and hidpipe-client getting renamed to muvm-hidpipe (and it's still autostarted by muvm-guest).

This simplifies the lifecycle management for hidpipe, ensuring it's tied to the microVM lifetime.

Co-developed-by: Sasha Finkelstein <fnkl.kernel@gmail.com>