### PR TITLE
muvm-guest: Find actual path for muvm-server before trying to execute it

### DIFF
--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -369,11 +369,17 @@ fn main() -> Result<()> {
     let muvm_server_path = find_muvm_exec("muvm-server")?;
 
     let mut muvm_guest_args: Vec<String> = vec![
-        muvm_guest_path,
+        muvm_guest_path
+            .to_str()
+            .context("Failed to process `muvm-guest` path as it contains invalid UTF-8")?
+            .to_owned(),
         username,
         format!("{uid}", uid = getuid().as_raw()),
         format!("{gid}", gid = getgid().as_raw()),
-        muvm_server_path,
+        muvm_server_path
+            .to_str()
+            .context("Failed to process `muvm-server` path as it contains invalid UTF-8")?
+            .to_owned(),
         command
             .to_str()
             .context("Failed to process command as it contains invalid UTF-8")?

--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result};
 use log::debug;
+use muvm::env::find_muvm_exec;
 use muvm::guest::cli_options::options;
 use muvm::guest::fex::setup_fex;
 use muvm::guest::mount::mount_filesystems;
@@ -65,7 +66,8 @@ fn main() -> Result<()> {
 
     // Before switching to the user, start another instance of muvm-server to serve
     // launch requests as root.
-    Command::new("muvm-server")
+    let muvm_server_path = find_muvm_exec("muvm-server")?;
+    Command::new(muvm_server_path)
         .spawn()
         .context("Failed to execute `muvm-server` as child process")?;
 


### PR DESCRIPTION
Otherwise this depends on where you run things from. In my case, I
would get:
    
      $ ./target/debug/muvm -- /bin/false
      Error: Failed to execute `muvm-server` as child process
    
      Caused by:
          No such file or directory (os error 2)
    
Signed-off-by: Stefano Brivio <sbrivio@redhat.com>
