### PR TITLE
muvm-guest: For debug builds, source muvm-hidpipe from current path a…

### DIFF
--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -57,7 +57,8 @@ fn main() -> Result<()> {
 
     configure_network()?;
 
-    Command::new("muvm-hidpipe")
+    let muvm_hidpipe_path = find_muvm_exec("muvm-hidpipe")?;
+    Command::new(muvm_hidpipe_path)
         .arg(format!("{}", options.uid))
         .spawn()
         .context("Failed to execute `muvm-hidpipe` as child process")?;


### PR DESCRIPTION
…s well

Same as commit d89ddbe7d022 ("env: For debug builds, source muvm binaries from current executable path"), but for muvm-hidpipe, which was imported into muvm by commit 44d33a39eb20 ("hidpipe: merge hidpipe project into muvm").

Otherwise I get:

  Error: Failed to execute `muvm-hidpipe` as child process

  Caused by:
      No such file or directory (os error 2)