### PR TITLE
muvm: Replace socat for interactive mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags",
  "errno",
+ "itoa",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -19,7 +19,7 @@ krun-sys = { path = "../krun-sys", version = "1.9.1", default-features = false, 
 log = { version = "0.4.21", default-features = false, features = ["kv"] }
 nix = { version = "0.29.0", default-features = false, features = ["event", "fs", "ioctl", "mman", "ptrace", "signal", "socket", "uio", "user"] }
 procfs = { version = "0.17.0", default-features = false, features = [] }
-rustix = { version = "0.38.34", default-features = false, features = ["fs", "mount", "process", "std", "stdio", "system", "use-libc-auxv"] }
+rustix = { version = "0.38.34", default-features = false, features = ["fs", "mount", "process", "pty", "std", "stdio", "system", "termios", "use-libc-auxv"] }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.117", default-features = false, features = ["std"] }
 tempfile = { version = "3.10.1", default-features = false, features = [] }

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -18,6 +18,7 @@ pub struct Options {
     pub fex_images: Vec<String>,
     pub sommelier: bool,
     pub interactive: bool,
+    pub tty: bool,
     pub command: PathBuf,
     pub command_args: Vec<String>,
 }
@@ -110,7 +111,11 @@ pub fn options() -> OptionParser<Options> {
         .switch();
     let interactive = long("interactive")
         .short('i')
-        .help("Allocate a tty guest-side and connect it to the current stdin/out")
+        .help("Attach to the command's stdin/out after starting it")
+        .switch();
+    let tty = long("tty")
+        .short('t')
+        .help("Allocate a tty for the command")
         .switch();
     let command = positional("COMMAND").help("the command you want to execute in the vm");
     let command_args = any::<String, _, _>("COMMAND_ARGS", |arg| {
@@ -130,6 +135,7 @@ pub fn options() -> OptionParser<Options> {
         fex_images,
         sommelier,
         interactive,
+        tty,
         // positionals
         command,
         command_args,

--- a/crates/muvm/src/launch.rs
+++ b/crates/muvm/src/launch.rs
@@ -11,17 +11,18 @@ use anyhow::{anyhow, Context, Result};
 use rustix::fs::{flock, FlockOperation};
 use uuid::Uuid;
 
-use super::utils::env::find_in_path;
 use crate::env::prepare_env_vars;
+use crate::tty::{run_io_host, RawTerminal};
 use crate::utils::launch::Launch;
-use rustix::path::Arg;
+use nix::unistd::unlink;
 use std::ops::Range;
-use std::process::{Child, Command};
+use std::os::unix::net::UnixListener;
+use std::process::ExitCode;
 
 pub const DYNAMIC_PORT_RANGE: Range<u32> = 50000..50200;
 
 pub enum LaunchResult {
-    LaunchRequested,
+    LaunchRequested(ExitCode),
     LockAcquired {
         cookie: Uuid,
         lock_file: File,
@@ -56,64 +57,75 @@ impl Display for LaunchError {
     }
 }
 
-fn start_socat() -> Result<(Child, u32)> {
+fn acquire_socket_lock() -> Result<(File, u32)> {
     let run_path = env::var("XDG_RUNTIME_DIR")
         .map_err(|e| anyhow!("unable to get XDG_RUNTIME_DIR: {:?}", e))?;
     let socket_dir = Path::new(&run_path).join("krun/socket");
-    let socat_path =
-        find_in_path("socat")?.ok_or_else(|| anyhow!("Unable to find socat in PATH"))?;
     for port in DYNAMIC_PORT_RANGE {
-        let path = socket_dir.join(format!("port-{}", port));
-        if path.exists() {
-            continue;
-        }
-        let child = Command::new(&socat_path)
-            .arg(format!("unix-l:{}", path.as_os_str().to_string_lossy()))
-            .arg("-,raw,echo=0")
-            .spawn()?;
-        return Ok((child, port));
+        let path = socket_dir.join(format!("port-{port}.lock"));
+        return Ok((
+            if !path.exists() {
+                let lock_file = File::create(path).context("Failed to create socket lock")?;
+                flock(&lock_file, FlockOperation::NonBlockingLockExclusive)
+                    .context("Failed to acquire socket lock")?;
+                lock_file
+            } else {
+                let lock_file = File::options()
+                    .write(true)
+                    .read(true)
+                    .open(path)
+                    .context("Failed to open lock file")?;
+                if flock(&lock_file, FlockOperation::NonBlockingLockExclusive).is_err() {
+                    continue;
+                }
+                lock_file
+            },
+            port,
+        ));
     }
     Err(anyhow!("Ran out of ports."))
-}
-
-fn escape_for_socat(s: String) -> String {
-    let mut ret = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            ':' | ',' | '!' | '"' | '\'' | '\\' | '(' | '[' | '{' => {
-                ret.push('\\');
-            },
-            _ => {},
-        }
-        ret.push(c);
-    }
-    ret
 }
 
 fn wrapped_launch(
     server_port: u32,
     cookie: Uuid,
-    mut command: PathBuf,
-    mut command_args: Vec<String>,
+    command: PathBuf,
+    command_args: Vec<String>,
     env: HashMap<String, String>,
     interactive: bool,
-) -> Result<()> {
+    tty: bool,
+) -> Result<ExitCode> {
     if !interactive {
-        return request_launch(server_port, cookie, command, command_args, env);
+        request_launch(server_port, cookie, command, command_args, env, 0, false)?;
+        return Ok(ExitCode::from(0));
     }
-    let (mut socat, vsock_port) = start_socat()?;
-    command_args.insert(0, command.to_string_lossy().into_owned());
-    command_args = vec![
-        format!("vsock:2:{}", vsock_port),
-        format!(
-            "exec:{},pty,setsid,stderr",
-            escape_for_socat(command_args.join(" "))
-        ),
-    ];
-    command = "socat".into();
-    request_launch(server_port, cookie, command, command_args, env)?;
-    socat.wait()?;
-    Ok(())
+    let run_path = env::var("XDG_RUNTIME_DIR")
+        .map_err(|e| anyhow!("unable to get XDG_RUNTIME_DIR: {:?}", e))?;
+    let socket_dir = Path::new(&run_path).join("krun/socket");
+    let (_lock, vsock_port) = acquire_socket_lock()?;
+    let path = socket_dir.join(format!("port-{vsock_port}"));
+    _ = unlink(&path);
+    let listener = UnixListener::bind(path).context("Failed to listen on vm socket")?;
+    let raw_tty = if tty {
+        Some(
+            RawTerminal::set()
+                .context("Asked to allocate a tty for the command, but stdin is not a tty")?,
+        )
+    } else {
+        None
+    };
+    request_launch(
+        server_port,
+        cookie,
+        command,
+        command_args,
+        env,
+        vsock_port,
+        tty,
+    )?;
+    let code = run_io_host(listener, tty)?;
+    drop(raw_tty);
+    Ok(ExitCode::from(code))
 }
 
 pub fn launch_or_lock(
@@ -122,16 +134,17 @@ pub fn launch_or_lock(
     command_args: Vec<String>,
     env: Vec<(String, Option<String>)>,
     interactive: bool,
+    tty: bool,
 ) -> Result<LaunchResult> {
     let running_server_port = env::var("MUVM_SERVER_PORT").ok();
     if let Some(port) = running_server_port {
         let port: u32 = port.parse()?;
         let env = prepare_env_vars(env)?;
         let cookie = read_cookie()?;
-        if let Err(err) = wrapped_launch(port, cookie, command, command_args, env, interactive) {
-            return Err(anyhow!("could not request launch to server: {err}"));
-        }
-        return Ok(LaunchResult::LaunchRequested);
+        return match wrapped_launch(port, cookie, command, command_args, env, interactive, tty) {
+            Err(err) => Err(anyhow!("could not request launch to server: {err}")),
+            Ok(code) => Ok(LaunchResult::LaunchRequested(code)),
+        };
     }
 
     let (lock_file, cookie) = lock_file()?;
@@ -154,6 +167,7 @@ pub fn launch_or_lock(
                     command_args.clone(),
                     env.clone(),
                     interactive,
+                    tty,
                 ) {
                     Err(err) => match err.downcast_ref::<LaunchError>() {
                         Some(&LaunchError::Connection(_)) => {
@@ -167,7 +181,7 @@ pub fn launch_or_lock(
                             return Err(anyhow!("could not request launch to server: {err}"));
                         },
                     },
-                    Ok(_) => return Ok(LaunchResult::LaunchRequested),
+                    Ok(code) => return Ok(LaunchResult::LaunchRequested(code)),
                 }
             }
         },
@@ -222,6 +236,8 @@ pub fn request_launch(
     command: PathBuf,
     command_args: Vec<String>,
     env: HashMap<String, String>,
+    vsock_port: u32,
+    tty: bool,
 ) -> Result<()> {
     let mut stream =
         TcpStream::connect(format!("127.0.0.1:{server_port}")).map_err(LaunchError::Connection)?;
@@ -231,6 +247,8 @@ pub fn request_launch(
         command,
         command_args,
         env,
+        vsock_port,
+        tty,
     };
 
     stream

--- a/crates/muvm/src/lib.rs
+++ b/crates/muvm/src/lib.rs
@@ -10,4 +10,5 @@ pub mod types;
 
 pub mod guest;
 pub mod server;
+pub mod tty;
 pub mod utils;

--- a/crates/muvm/src/monitor.rs
+++ b/crates/muvm/src/monitor.rs
@@ -44,7 +44,7 @@ fn set_guest_pressure(server_port: u32, cookie: Uuid, pressure: GuestPressure) -
         let command = PathBuf::from("/muvmdropcaches");
         let command_args = vec![];
         let env = HashMap::new();
-        request_launch(server_port, cookie, command, command_args, env)?;
+        request_launch(server_port, cookie, command, command_args, env, 0, false)?;
     }
 
     let wsf: u32 = pressure.into();
@@ -53,7 +53,7 @@ fn set_guest_pressure(server_port: u32, cookie: Uuid, pressure: GuestPressure) -
     let command = PathBuf::from("/sbin/sysctl");
     let command_args = vec![format!("vm.watermark_scale_factor={}", wsf)];
     let env = HashMap::new();
-    request_launch(server_port, cookie, command, command_args, env)
+    request_launch(server_port, cookie, command, command_args, env, 0, false)
 }
 
 fn run(server_port: u32, cookie: Uuid) {

--- a/crates/muvm/src/server/worker.rs
+++ b/crates/muvm/src/server/worker.rs
@@ -1,13 +1,25 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::fs::File;
-use std::io::Write;
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::net::UnixStream;
 use std::os::unix::process::ExitStatusExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
-use std::{env, io};
+use std::{env, io, thread};
 
 use anyhow::{anyhow, Context, Result};
 use log::{debug, error};
+use nix::errno::Errno;
+use nix::sys::epoll::{Epoll, EpollCreateFlags, EpollEvent, EpollFlags, EpollTimeout};
+use nix::sys::socket::{connect, socket, AddressFamily, SockFlag, SockType, VsockAddr};
+use nix::unistd::{pipe, setsid};
+use rustix::process::ioctl_tiocsctty;
+use rustix::pty::{ptsname, unlockpt};
+use rustix::termios::{tcsetwinsize, Winsize};
 use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufStream};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::process::{Child, Command};
@@ -19,10 +31,15 @@ use uuid::Uuid;
 
 use crate::utils::launch::Launch;
 use crate::utils::stdio::make_stdout_stderr;
+use crate::utils::tty::*;
 
 pub enum ConnRequest {
     DropCaches,
-    ExecuteCommand { command: PathBuf, child: Child },
+    ExecuteCommand {
+        command: PathBuf,
+        child: Child,
+        stop_pipe: Option<OwnedFd>,
+    },
 }
 
 #[derive(Debug)]
@@ -30,7 +47,7 @@ pub struct Worker {
     cookie: Uuid,
     listener_stream: TcpListenerStream,
     state_tx: watch::Sender<State>,
-    child_set: JoinSet<(PathBuf, ChildResult)>,
+    child_set: JoinSet<(PathBuf, ChildResult, Option<OwnedFd>)>,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
@@ -69,8 +86,8 @@ impl Worker {
                     match handle_connection(self.cookie, stream).await {
                         Ok(request) => match request {
                             ConnRequest::DropCaches => {},
-                            ConnRequest::ExecuteCommand {command, mut child } => {
-                                self.child_set.spawn(async move { (command, child.wait().await) });
+                            ConnRequest::ExecuteCommand {command, mut child, stop_pipe } => {
+                                self.child_set.spawn(async move { (command, child.wait().await, stop_pipe) });
                                 self.set_child_processes(self.child_set.len());
                             }
                         },
@@ -85,11 +102,15 @@ impl Worker {
         }
     }
 
-    fn handle_child_join(&self, res: Result<(PathBuf, ChildResult), JoinError>) {
+    fn handle_child_join(&self, res: Result<(PathBuf, ChildResult, Option<OwnedFd>), JoinError>) {
         match res {
-            Ok((command, res)) => match res {
+            Ok((command, res, stop_pipe)) => match res {
                 Ok(status) => {
                     debug!(command:?; "child process exited");
+                    if let Some(sp) = stop_pipe {
+                        let code = status.code().unwrap_or_default() as u8;
+                        _ = File::from(sp).write_all(&[code]);
+                    }
                     if !status.success() {
                         if let Some(code) = status.code() {
                             eprintln!("{command:?} process exited with status code: {code}");
@@ -182,6 +203,8 @@ async fn handle_connection(
         command,
         command_args,
         env,
+        vsock_port,
+        tty,
     } = read_request(&mut stream).await?;
     debug!(command:?, command_args:?, env:?; "received launch request");
     if cookie != server_cookie {
@@ -209,14 +232,51 @@ async fn handle_connection(
 
     envs.extend(env);
 
-    let (stdout, stderr) = make_stdout_stderr(&command, &envs)?;
+    let stdin;
+    let stdout;
+    let stderr;
+    let mut tty_fd = None;
+    if vsock_port == 0 {
+        (stdout, stderr) = make_stdout_stderr(&command, &envs)?;
+        stdin = Stdio::null();
+    } else if !tty {
+        stdin = Stdio::piped();
+        stdout = Stdio::piped();
+        stderr = Stdio::piped();
+    } else {
+        let tty_m = File::options()
+            .read(true)
+            .write(true)
+            .custom_flags(nix::libc::O_NOCTTY)
+            .open("/dev/ptmx")?;
+        let tty_s_path = ptsname(&tty_m, Vec::new())?;
+        unlockpt(&tty_m)?;
+        let tty_s = File::options()
+            .read(true)
+            .write(true)
+            .open(OsString::from_vec(tty_s_path.into_bytes()))?;
+        stdin = Stdio::from(tty_s.try_clone()?);
+        stdout = Stdio::from(tty_s.try_clone()?);
+        stderr = Stdio::from(tty_s);
+        tty_fd = Some(tty_m);
+    }
 
-    let res = Command::new(&command)
-        .args(command_args)
+    let mut cmd = Command::new(&command);
+    cmd.args(command_args)
         .envs(envs)
-        .stdin(Stdio::null())
+        .stdin(stdin)
         .stdout(stdout)
-        .stderr(stderr)
+        .stderr(stderr);
+    if tty {
+        unsafe {
+            cmd.pre_exec(|| {
+                setsid()?;
+                ioctl_tiocsctty(io::stdin())?;
+                Ok(())
+            });
+        }
+    }
+    let res = cmd
         .spawn()
         .with_context(|| format!("Failed to execute {command:?} as child process"));
     if let Err(err) = &res {
@@ -227,5 +287,149 @@ async fn handle_connection(
     }
     stream.flush().await.ok();
 
-    res.map(|child| ConnRequest::ExecuteCommand { command, child })
+    res.map(|mut child| {
+        let stop_pipe;
+        if vsock_port != 0 {
+            let (stop_r, stop_w) = pipe().unwrap();
+            stop_pipe = Some(stop_w);
+            let stdin: OwnedFd;
+            let stdout;
+            let stderr;
+            if tty {
+                stdin = tty_fd.unwrap().into();
+                stdout = stdin.try_clone().unwrap();
+                stderr = None;
+            } else {
+                stdin = child.stdin.take().unwrap().into_owned_fd().unwrap();
+                stdout = child.stdout.take().unwrap().into_owned_fd().unwrap();
+                stderr = Some(child.stderr.take().unwrap().into_owned_fd().unwrap());
+            }
+            thread::spawn(move || {
+                _ = run_io_guest(stdin, stdout, stderr, stop_r, vsock_port);
+            });
+        } else {
+            stop_pipe = None;
+        }
+        ConnRequest::ExecuteCommand {
+            command,
+            child,
+            stop_pipe,
+        }
+    })
+}
+
+fn run_io_guest(
+    stdin: OwnedFd,
+    stdout: OwnedFd,
+    stderr: Option<OwnedFd>,
+    stop_pipe: OwnedFd,
+    vsock_port: u32,
+) -> Result<()> {
+    let mut stdin = Some(File::from(stdin));
+    let mut stdout = File::from(stdout);
+    let mut stderr = stderr.map(File::from);
+    let mut stop_pipe = File::from(stop_pipe);
+    let vsock_fd = socket(
+        AddressFamily::Vsock,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )?;
+    connect(
+        vsock_fd.as_raw_fd(),
+        &VsockAddr::new(nix::libc::VMADDR_CID_HOST, vsock_port),
+    )?;
+    let mut vsock = UnixStream::from(vsock_fd);
+    let epoll = Epoll::new(EpollCreateFlags::empty())?;
+    epoll.add(&stdout, EpollEvent::new(EpollFlags::EPOLLIN, 1))?;
+    if stderr.is_some() {
+        epoll.add(
+            stderr.as_ref().unwrap(),
+            EpollEvent::new(EpollFlags::EPOLLIN, 2),
+        )?;
+    }
+    epoll.add(&vsock, EpollEvent::new(EpollFlags::EPOLLIN, 3))?;
+    epoll.add(&stop_pipe, EpollEvent::new(EpollFlags::EPOLLIN, 4))?;
+    loop {
+        let mut evts = [EpollEvent::empty()];
+        match epoll.wait(&mut evts, EpollTimeout::NONE) {
+            Err(Errno::EINTR) | Ok(0) => {
+                continue;
+            },
+            Ok(_) => {},
+            e => {
+                e?;
+            },
+        }
+        if evts[0].events().contains(EpollFlags::EPOLLIN) {
+            match evts[0].data() {
+                1 | 2 => {
+                    let mut buf = [0; 4096];
+                    let len;
+                    let opc;
+                    if evts[0].data() == 1 {
+                        len = stdout.read(&mut buf)?;
+                        opc = CMD_WRITE_STDOUT;
+                    } else {
+                        len = stderr.as_mut().unwrap().read(&mut buf)?;
+                        opc = CMD_WRITE_STDERR;
+                    }
+                    let cmd = ((len << CMD_SHIFT) as u16 | opc).to_le_bytes();
+                    vsock.write_all(&cmd)?;
+                    vsock.write_all(&buf[..len])?;
+                },
+                3 => {
+                    let mut cmd = [0; 2];
+                    vsock.read_exact(&mut cmd)?;
+                    let cmd = u16::from_le_bytes(cmd);
+                    let opc = cmd & CMD_MASK;
+                    if opc == CMD_WRITE_STDIN {
+                        let len = cmd as usize >> CMD_SHIFT;
+                        if len == 0 {
+                            stdin = None;
+                        } else {
+                            let mut buf = vec![0; len];
+                            vsock.read_exact(&mut buf)?;
+                            stdin.as_mut().unwrap().write_all(&buf)?;
+                        }
+                    } else if opc == CMD_UPDATE_SIZE {
+                        let mut data = [0; 4];
+                        vsock.read_exact(&mut data)?;
+                        if let Some(stdin) = stdin.as_ref() {
+                            tcsetwinsize(
+                                stdin,
+                                Winsize {
+                                    ws_col: u16::from_le_bytes(data[..2].try_into().unwrap()),
+                                    ws_row: u16::from_le_bytes(data[2..].try_into().unwrap()),
+                                    ws_xpixel: 0,
+                                    ws_ypixel: 0,
+                                },
+                            )?;
+                        }
+                    } else {
+                        unreachable!();
+                    }
+                },
+                4 => {
+                    let mut code = [0];
+                    stop_pipe.read_exact(&mut code)?;
+                    let cmd = ((code[0] as u16) << CMD_SHIFT) | CMD_EXIT;
+                    vsock.write_all(&cmd.to_le_bytes())?;
+                    break Ok(());
+                },
+                _ => unreachable!(),
+            }
+        }
+        if evts[0]
+            .events()
+            .intersects(EpollFlags::EPOLLERR | EpollFlags::EPOLLHUP)
+        {
+            match evts[0].data() {
+                1 => epoll.delete(&stdout)?,
+                2 => epoll.delete(stderr.as_ref().unwrap())?,
+                3 | 4 => break Ok(()),
+                _ => unreachable!(),
+            }
+        }
+    }
 }

--- a/crates/muvm/src/tty.rs
+++ b/crates/muvm/src/tty.rs
@@ -1,0 +1,154 @@
+use std::fs::File;
+use std::io::{stdout, Read, Write};
+use std::mem::ManuallyDrop;
+use std::os::fd::{AsFd, FromRawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+
+use crate::utils::tty::*;
+use anyhow::Result;
+use nix::errno::Errno;
+use nix::sys::epoll::{Epoll, EpollCreateFlags, EpollEvent, EpollFlags, EpollTimeout};
+use nix::sys::signal::{sigprocmask, SigSet, SigmaskHow, Signal};
+use nix::sys::signalfd::SignalFd;
+use rustix::termios::{
+    tcgetattr, tcgetwinsize, tcsetattr, ControlModes, InputModes, LocalModes, OptionalActions,
+    OutputModes, SpecialCodeIndex, Termios,
+};
+
+fn process_remote_msg(
+    remote: &mut UnixStream,
+    is_tty: bool,
+    stdout: &mut File,
+    stderr: &mut File,
+) -> Result<Option<u8>> {
+    let mut cmd_buf = [0u8; 2];
+    remote.read_exact(&mut cmd_buf)?;
+    let cmd = u16::from_le_bytes(cmd_buf);
+    let opc = cmd & CMD_MASK;
+    if opc == CMD_WRITE_STDOUT || opc == CMD_WRITE_STDERR {
+        let len = cmd as usize >> CMD_SHIFT;
+        let mut data_buf = vec![0; len];
+        remote.read_exact(&mut data_buf)?;
+        if opc == CMD_WRITE_STDOUT || is_tty {
+            stdout.write_all(&data_buf)?;
+        } else {
+            stderr.write_all(&data_buf)?;
+        }
+    } else if opc == CMD_EXIT {
+        return Ok(Some((cmd >> CMD_SHIFT) as u8));
+    }
+    Ok(None)
+}
+
+fn process_stdin(remote: &mut UnixStream, epoll: &Epoll, stdin: &mut File) -> Result<()> {
+    let mut data = [0; 4096];
+    let len = stdin.read(&mut data)?;
+    let data = &data[..len];
+    let cmd = CMD_WRITE_STDIN | (len << CMD_SHIFT) as u16;
+    remote.write_all(&cmd.to_le_bytes())?;
+    if len == 0 {
+        epoll.delete(stdin)?;
+    } else {
+        remote.write_all(data)?;
+    }
+    Ok(())
+}
+
+fn update_size(remote: &mut UnixStream) -> Result<()> {
+    let win_sz = tcgetwinsize(stdout())?;
+    let mut buf = [0; 6];
+    buf[0..2].copy_from_slice(&CMD_UPDATE_SIZE.to_le_bytes());
+    buf[2..4].copy_from_slice(&win_sz.ws_col.to_le_bytes());
+    buf[4..6].copy_from_slice(&win_sz.ws_row.to_le_bytes());
+    remote.write_all(&buf)?;
+    Ok(())
+}
+
+pub struct RawTerminal(Termios);
+
+impl RawTerminal {
+    pub fn set() -> Result<RawTerminal> {
+        let old_attr = tcgetattr(stdout())?;
+        let mut new_attr = old_attr.clone();
+        new_attr.special_codes[SpecialCodeIndex::VMIN] = 1;
+        new_attr.special_codes[SpecialCodeIndex::VTIME] = 0;
+        new_attr.input_modes.remove(
+            InputModes::IGNBRK
+                | InputModes::BRKINT
+                | InputModes::PARMRK
+                | InputModes::ISTRIP
+                | InputModes::INLCR
+                | InputModes::IGNCR
+                | InputModes::ICRNL
+                | InputModes::IXON,
+        );
+        new_attr.output_modes.remove(OutputModes::OPOST);
+        new_attr.local_modes.remove(
+            LocalModes::ECHO
+                | LocalModes::ECHONL
+                | LocalModes::ICANON
+                | LocalModes::ISIG
+                | LocalModes::IEXTEN,
+        );
+        new_attr
+            .control_modes
+            .remove(ControlModes::CSIZE | ControlModes::PARENB);
+        new_attr.control_modes.insert(ControlModes::CS8);
+        tcsetattr(stdout(), OptionalActions::Drain, &new_attr)?;
+        Ok(RawTerminal(old_attr))
+    }
+}
+
+impl Drop for RawTerminal {
+    fn drop(&mut self) {
+        _ = tcsetattr(stdout(), OptionalActions::Drain, &self.0);
+    }
+}
+
+pub fn run_io_host(listener: UnixListener, is_tty: bool) -> Result<u8> {
+    let mut stdin = unsafe { ManuallyDrop::new(File::from_raw_fd(0)) };
+    let mut stdout = unsafe { ManuallyDrop::new(File::from_raw_fd(1)) };
+    let mut stderr = unsafe { ManuallyDrop::new(File::from_raw_fd(2)) };
+    let mut remote = listener.accept()?.0;
+    let epoll = Epoll::new(EpollCreateFlags::empty())?;
+    let signalfd = SignalFd::new(&SigSet::from(Signal::SIGWINCH))?;
+    epoll.add(&remote, EpollEvent::new(EpollFlags::EPOLLIN, 1))?;
+    epoll.add(stdin.as_fd(), EpollEvent::new(EpollFlags::EPOLLIN, 2))?;
+    if is_tty {
+        epoll.add(&signalfd, EpollEvent::new(EpollFlags::EPOLLIN, 3))?;
+        sigprocmask(
+            SigmaskHow::SIG_BLOCK,
+            Some(&SigSet::from(Signal::SIGWINCH)),
+            None,
+        )?;
+        update_size(&mut remote)?;
+    }
+    loop {
+        let mut evts = [EpollEvent::empty()];
+        match epoll.wait(&mut evts, EpollTimeout::NONE) {
+            Err(Errno::EINTR) | Ok(0) => {
+                continue;
+            },
+            Ok(_) => {},
+            e => {
+                e.unwrap();
+            },
+        }
+        match evts[0].data() {
+            1 => {
+                if let Some(exit) =
+                    process_remote_msg(&mut remote, is_tty, &mut stdout, &mut stderr)?
+                {
+                    break Ok(exit);
+                }
+            },
+            2 => process_stdin(&mut remote, &epoll, &mut stdin)?,
+            3 => {
+                if signalfd.read_signal()?.is_some() {
+                    update_size(&mut remote)?;
+                }
+            },
+            _ => unreachable!(),
+        }
+    }
+}

--- a/crates/muvm/src/utils/launch.rs
+++ b/crates/muvm/src/utils/launch.rs
@@ -10,4 +10,6 @@ pub struct Launch {
     pub command: PathBuf,
     pub command_args: Vec<String>,
     pub env: HashMap<String, String>,
+    pub vsock_port: u32,
+    pub tty: bool,
 }

--- a/crates/muvm/src/utils/mod.rs
+++ b/crates/muvm/src/utils/mod.rs
@@ -2,3 +2,4 @@ pub mod env;
 pub mod fs;
 pub mod launch;
 pub mod stdio;
+pub mod tty;

--- a/crates/muvm/src/utils/tty.rs
+++ b/crates/muvm/src/utils/tty.rs
@@ -1,0 +1,7 @@
+pub const CMD_MASK: u16 = 0x3;
+pub const CMD_SHIFT: u32 = 2;
+pub const CMD_WRITE_STDOUT: u16 = 0;
+pub const CMD_WRITE_STDERR: u16 = 1;
+pub const CMD_WRITE_STDIN: u16 = 0;
+pub const CMD_UPDATE_SIZE: u16 = 1;
+pub const CMD_EXIT: u16 = 2;


### PR DESCRIPTION
Socat's tty mode has issues with window resizing
as it does not pass through SIGWINCH. Also add
a tty-less interactive mode, for usage from scripts and similar.