### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "muvm"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muvm"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Sergio Lopez <slp@redhat.com>", "Teoh Han Hui <teohhanhui@gmail.com>", "Sasha Finkelstein <fnkl.kernel@gmail.com>", "Asahi Lina <lina@asahilina.net>"]
 edition = "2021"
 rust-version = "1.77.0"


### PR DESCRIPTION
Set up the stage for a new release. Bump minor version too, since this release includes breaking changes to the command line (-i behaves differently, and we default to muvm-x11bridge instead of sommelier).