### PR TITLE
Support empty DISPLAY in xauth

### DIFF
--- a/crates/muvm/src/guest/x11.rs
+++ b/crates/muvm/src/guest/x11.rs
@@ -65,7 +65,7 @@ where
             }
 
             // Check for the correct host display
-            if display != host_display.as_bytes() {
+            if !display.is_empty() && display != host_display.as_bytes() {
                 continue;
             }
 


### PR DESCRIPTION
Currently x11bridge is broken on Gnome, because Gnome seems to create the wildcard entry in xauth with an empty DISPLAY. For example:
```~/t/muvm ❯❯❯ xauth list                                                                                                                                                                                          ✘ 1 
asahi/unix:  MIT-MAGIC-COOKIE-1  90e94fb5b89d6c1f5e512d58a1c6b8d3
#ffff#6173616869#:  MIT-MAGIC-COOKIE-1  90e94fb5b89d6c1f5e512d58a1c6b8d3
```

x11bridge then filters it out, resulting in an empty xauth file.

This makes x11bridge accept the Gnome entry, fixing X11.

I searched around a bit why Gnome is doing this, only thing I could find is https://xorg.freedesktop.narkive.com/zzRJsYVZ/is-xauth-entry-without-display-number-valid.