### PR TITLE
x11: Fix XAUTHORITY handling for wildcard DISPLAY

### DIFF
--- a/crates/muvm/src/guest/x11.rs
+++ b/crates/muvm/src/guest/x11.rs
@@ -65,7 +65,7 @@ where
             }
 
             // Check for the correct host display
-            if display != host_display.as_bytes() {
+            if !display.is_empty() && display != host_display.as_bytes() {
                 continue;
             }
 


### PR DESCRIPTION
Apparently GNOME does this (empty display field)...