### PR TITLE
Port passthrough

### DIFF
--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -264,7 +264,9 @@ fn main() -> Result<ExitCode> {
                 .context("Failed to connect to `passt`")?
                 .into()
         } else {
-            start_passt().context("Failed to start `passt`")?.into()
+            start_passt(&options.publish_ports)
+                .context("Failed to start `passt`")?
+                .into()
         };
         // SAFETY: `passt_fd` is an `OwnedFd` and consumed to prevent closing on drop.
         // See https://doc.rust-lang.org/std/io/index.html#io-safety

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -18,6 +18,7 @@ pub struct Options {
     pub interactive: bool,
     pub tty: bool,
     pub privileged: bool,
+    pub publish_ports: Vec<String>,
     pub command: PathBuf,
     pub command_args: Vec<String>,
 }
@@ -111,6 +112,15 @@ pub fn options() -> OptionParser<Options> {
         This notably does not allow root access to the host fs.",
         )
         .switch();
+    let publish_ports = long("publish")
+        .short('p')
+        .help(
+            "
+    Publish a guest’s port, or range of ports, to the host.
+        The syntax is similar to podman/docker.",
+        )
+        .argument::<String>("[[IP:][HOST_PORT]:]GUEST_PORT[/PROTOCOL]")
+        .many();
     let command = positional("COMMAND").help("the command you want to execute in the vm");
     let command_args = any::<String, _, _>("COMMAND_ARGS", |arg| {
         (!["--help", "-h"].contains(&&*arg)).then_some(arg)
@@ -129,6 +139,7 @@ pub fn options() -> OptionParser<Options> {
         interactive,
         tty,
         privileged,
+        publish_ports,
         // positionals
         command,
         command_args,

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -13,7 +13,6 @@ pub struct Options {
     pub mem: Option<MiB>,
     pub vram: Option<MiB>,
     pub passt_socket: Option<PathBuf>,
-    pub server_port: u32,
     pub fex_images: Vec<String>,
     pub merged_rootfs: bool,
     pub interactive: bool,
@@ -98,12 +97,6 @@ pub fn options() -> OptionParser<Options> {
         .help("Instead of starting passt, connect to passt socket at PATH")
         .argument("PATH")
         .optional();
-    let server_port = long("server-port")
-        .short('p')
-        .help("Set the port to be used in server mode")
-        .argument("SERVER_PORT")
-        .fallback(3334)
-        .display_fallback();
     let interactive = long("interactive")
         .short('i')
         .help("Attach to the command's stdin/out after starting it")
@@ -131,7 +124,6 @@ pub fn options() -> OptionParser<Options> {
         mem,
         vram,
         passt_socket,
-        server_port,
         fex_images,
         merged_rootfs,
         interactive,

--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -15,7 +15,7 @@ use muvm::guest::socket::setup_socket_proxy;
 use muvm::guest::user::setup_user;
 use muvm::guest::x11::setup_x11_forwarding;
 use muvm::guest::x11bridge::start_x11bridge;
-use muvm::utils::launch::GuestConfiguration;
+use muvm::utils::launch::{GuestConfiguration, PULSE_SOCKET};
 use nix::unistd::{Gid, Uid};
 use rustix::process::{getrlimit, setrlimit, Resource};
 
@@ -94,7 +94,7 @@ fn main() -> Result<()> {
     std::fs::create_dir(&pulse_path)
         .context("Failed to create `pulse` directory in `XDG_RUNTIME_DIR`")?;
     let pulse_path = pulse_path.join("native");
-    setup_socket_proxy(pulse_path, 3333)?;
+    setup_socket_proxy(pulse_path, PULSE_SOCKET)?;
 
     if let Some(host_display) = options.host_display {
         setup_x11_forwarding(run_path, &host_display)?;
@@ -108,13 +108,5 @@ fn main() -> Result<()> {
     });
 
     let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
-        server_main(
-            options.server_port,
-            options.server_cookie,
-            options.command.command,
-            options.command.command_args,
-        )
-        .await
-    })
+    rt.block_on(async { server_main(options.command.command, options.command.command_args).await })
 }

--- a/crates/muvm/src/guest/hidpipe.rs
+++ b/crates/muvm/src/guest/hidpipe.rs
@@ -3,6 +3,7 @@ use crate::hidpipe_common::{
     empty_input_event, struct_to_socket, AddDevice, ClientHello, FFErase, FFUpload, InputEvent,
     MessageType, RemoveDevice, ServerHello,
 };
+use crate::utils::launch::HIDPIPE_SOCKET;
 use input_linux::bitmask::BitmaskTrait;
 use input_linux::{
     AbsoluteAxis, AbsoluteInfo, Bitmask, EventKind, ForceFeedbackKind, InputProperty, Key, LedKind,
@@ -161,7 +162,7 @@ pub fn start_hidpipe(user_id: u32) {
         None,
     )
     .unwrap();
-    connect(sock_fd.as_raw_fd(), &VsockAddr::new(2, 3334)).unwrap();
+    connect(sock_fd.as_raw_fd(), &VsockAddr::new(2, HIDPIPE_SOCKET)).unwrap();
     let mut sock = UnixStream::from(sock_fd);
     let c_hello = ClientHello { version: 0 };
     let c_hello_data = unsafe {

--- a/crates/muvm/src/guest/socket.rs
+++ b/crates/muvm/src/guest/socket.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use crate::utils::env::find_in_path;
 use crate::utils::stdio::make_stdout_stderr;
 
-pub fn setup_socket_proxy<P>(socket_path: P, port: u16) -> Result<()>
+pub fn setup_socket_proxy<P>(socket_path: P, port: u32) -> Result<()>
 where
     P: AsRef<Path>,
 {

--- a/crates/muvm/src/net.rs
+++ b/crates/muvm/src/net.rs
@@ -7,6 +7,74 @@ use anyhow::{Context, Result};
 use log::debug;
 use rustix::io::dup;
 
+struct PublishSpec<'a> {
+    udp: bool,
+    guest_range: (u32, u32),
+    host_range: (u32, u32),
+    ip: &'a str,
+}
+
+fn parse_range(r: &str) -> Result<(u32, u32)> {
+    Ok(if let Some(pos) = r.find('-') {
+        (r[..pos].parse()?, r[pos + 1..].parse()?)
+    } else {
+        let val = r.parse()?;
+        (val, val)
+    })
+}
+
+impl PublishSpec<'_> {
+    fn parse(mut arg: &str) -> Result<PublishSpec> {
+        let mut udp = false;
+        if arg.ends_with("/udp") {
+            udp = true;
+        }
+        if let Some(pos) = arg.rfind('/') {
+            arg = &arg[..pos];
+        }
+        let guest_range_start = arg.rfind(':');
+        let guest_range = parse_range(&arg[guest_range_start.map(|x| x + 1).unwrap_or(0)..])?;
+        let mut ip = "";
+        let host_range = match guest_range_start {
+            None => guest_range,
+            Some(guest_range_start) => {
+                arg = &arg[..guest_range_start];
+                let ip_start = arg.rfind(':');
+                if let Some(ip_start) = ip_start {
+                    ip = &arg[..ip_start];
+                    arg = &arg[ip_start + 1..];
+                }
+                if arg.is_empty() {
+                    guest_range
+                } else {
+                    parse_range(arg)?
+                }
+            },
+        };
+        Ok(PublishSpec {
+            ip,
+            host_range,
+            guest_range,
+            udp,
+        })
+    }
+    fn to_args(&self) -> [String; 2] {
+        let optslash = if self.ip.is_empty() { "" } else { "/" };
+        [
+            if self.udp { "-u" } else { "-t" }.to_owned(),
+            format!(
+                "{}{}{}-{}:{}-{}",
+                self.ip,
+                optslash,
+                self.host_range.0,
+                self.host_range.1,
+                self.guest_range.0,
+                self.guest_range.1
+            ),
+        ]
+    }
+}
+
 pub fn connect_to_passt<P>(passt_socket_path: P) -> Result<UnixStream>
 where
     P: AsRef<Path>,
@@ -14,7 +82,7 @@ where
     Ok(UnixStream::connect(passt_socket_path)?)
 }
 
-pub fn start_passt() -> Result<UnixStream> {
+pub fn start_passt(publish_ports: &[String]) -> Result<UnixStream> {
     // SAFETY: The child process should not inherit the file descriptor of
     // `parent_socket`. There is no documented guarantee of this, but the
     // implementation as of writing atomically sets `SOCK_CLOEXEC`.
@@ -35,13 +103,16 @@ pub fn start_passt() -> Result<UnixStream> {
 
     debug!(fd = child_fd.as_raw_fd(); "passing fd to passt");
 
+    let mut cmd = Command::new("passt");
     // SAFETY: `child_fd` is an `OwnedFd` and consumed to prevent closing on drop,
     // as it will now be owned by the child process.
     // See https://doc.rust-lang.org/std/io/index.html#io-safety
-    let child = Command::new("passt")
-        .args(["-q", "-f", "--fd"])
-        .arg(format!("{}", child_fd.into_raw_fd()))
-        .spawn();
+    cmd.args(["-q", "-f", "--fd"])
+        .arg(format!("{}", child_fd.into_raw_fd()));
+    for spec in publish_ports {
+        cmd.args(PublishSpec::parse(spec)?.to_args());
+    }
+    let child = cmd.spawn();
     if let Err(err) = child {
         return Err(err).context("Failed to execute `passt` as child process");
     }

--- a/crates/muvm/src/net.rs
+++ b/crates/muvm/src/net.rs
@@ -14,7 +14,7 @@ where
     Ok(UnixStream::connect(passt_socket_path)?)
 }
 
-pub fn start_passt(server_port: u32) -> Result<UnixStream> {
+pub fn start_passt() -> Result<UnixStream> {
     // SAFETY: The child process should not inherit the file descriptor of
     // `parent_socket`. There is no documented guarantee of this, but the
     // implementation as of writing atomically sets `SOCK_CLOEXEC`.
@@ -39,9 +39,7 @@ pub fn start_passt(server_port: u32) -> Result<UnixStream> {
     // as it will now be owned by the child process.
     // See https://doc.rust-lang.org/std/io/index.html#io-safety
     let child = Command::new("passt")
-        .args(["-q", "-f", "-t"])
-        .arg(format!("{server_port}:{server_port}"))
-        .arg("--fd")
+        .args(["-q", "-f", "--fd"])
         .arg(format!("{}", child_fd.into_raw_fd()))
         .spawn();
     if let Err(err) = child {

--- a/crates/muvm/src/utils/launch.rs
+++ b/crates/muvm/src/utils/launch.rs
@@ -1,11 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use uuid::Uuid;
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct Launch {
-    pub cookie: Uuid,
     pub command: PathBuf,
     pub command_args: Vec<String>,
     pub env: HashMap<String, String>,
@@ -17,11 +15,13 @@ pub struct Launch {
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct GuestConfiguration {
     pub command: Launch,
-    pub server_port: u32,
     pub username: String,
     pub uid: u32,
     pub gid: u32,
     pub host_display: Option<String>,
-    pub server_cookie: Uuid,
     pub merged_rootfs: bool,
 }
+
+pub const PULSE_SOCKET: u32 = 3333;
+pub const HIDPIPE_SOCKET: u32 = PULSE_SOCKET + 1;
+pub const MUVM_GUEST_SOCKET: u32 = HIDPIPE_SOCKET + 1;


### PR DESCRIPTION
Add an ability to configure the set of published ports via command line switches. 

This is a continuation from #134 that moves all internal communications to vsock ports. 