### PR TITLE
krun-sys: find libkrun using pkg-config

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Download libkrun.h
         run: sudo curl -o /usr/include/libkrun.h https://raw.githubusercontent.com/containers/libkrun/refs/heads/main/include/libkrun.h
 
+      - name: Download libkrun.pc
+        run: sudo curl -o /usr/lib/x86_64-linux-gnu/pkgconfig/libkrun.pc https://gist.githubusercontent.com/slp/b5761d225d96d2c8879392a7b1611aee/raw/79b81aaabc34648d27916f4abcf7502d98915c50/libkrun-ubuntu.pc
+
       - name: Formatting (rustfmt)
         run: cargo fmt -- --check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,9 +340,10 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "krun-sys"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "bindgen",
+ "pkg-config",
 ]
 
 [[package]]

--- a/crates/krun-sys/Cargo.toml
+++ b/crates/krun-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-sys"
-version = "1.9.1"
+version = "1.10.1"
 edition = "2021"
 rust-version = "1.77.0"
 description = "Rust bindings for libkrun"
@@ -10,6 +10,7 @@ links = "krun"
 
 [build-dependencies]
 bindgen = { version = "0.69.4", default-features = false }
+pkg-config = { version = "0.3", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
This enables the use of non-system-wide installations of libkrun by exporting the right PKG_CONFIG_PATH.