### PR TITLE
Add init-command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ``` sh
 Usage: muvm [-c=CPU_LIST]... [-e=ENV]... [--mem=MEM] [--vram=VRAM] [--passt-socket=PATH] [-f=
 FEX_IMAGE]... [-m] [-i] [-t] [--privileged] [-p=<[[IP:][HOST_PORT]:]GUEST_PORT[/PROTOCOL]>]... [
---emu=EMU] COMMAND [COMMAND_ARGS]...
+--emu=EMU] [-x=COMMAND]... COMMAND [COMMAND_ARGS]...
 
 Available positional items:
     COMMAND                  the command you want to execute in the vm
@@ -54,6 +54,9 @@ Available options:
                                       Valid options are "box" and "fex". If this argument is not
                                       present, muvm will try to use FEX, falling back to Box if it
                                       can't be found.
+    -x, --execute-pre=COMMAND  Command to run inside the VM before guest server starts.
+                                     Can be used for e.g. setting up additional mounts.
+                                     Can be specified multiple times.
     -h, --help               Prints help information
 ```
 

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -397,6 +397,7 @@ fn main() -> Result<ExitCode> {
         merged_rootfs: options.merged_rootfs,
         emulator: options.emulator,
         cwd,
+        init_commands: options.init_commands,
     };
     let mut muvm_config_file = NamedTempFile::new()
         .context("Failed to create a temporary file to store the muvm guest config")?;

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -346,11 +346,12 @@ fn main() -> Result<ExitCode> {
         }
     }
 
-    let username = env::var("USER").context("Failed to get username from environment")?;
-    let user = User::from_name(&username)
+    let uid = getuid().as_raw();
+    let user = User::from_uid(uid.into())
         .map_err(Into::into)
         .and_then(|user| user.ok_or_else(|| anyhow!("requested entry not found")))
-        .with_context(|| format!("Failed to get user `{username}` from user database"))?;
+        .with_context(|| format!("Failed to get user `{uid}` from user database"))?;
+
     let workdir_path = CString::new(
         user.dir
             .to_str()
@@ -389,8 +390,7 @@ fn main() -> Result<ExitCode> {
             tty: false,
             privileged: false,
         },
-        username,
-        uid: getuid().as_raw(),
+        uid,
         gid: getgid().as_raw(),
         host_display: display,
         merged_rootfs: options.merged_rootfs,

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -380,6 +380,7 @@ fn main() -> Result<ExitCode> {
 
     let muvm_guest_path = find_muvm_exec("muvm-guest")?;
 
+    let cwd = env::current_dir()?;
     let display = env::var("DISPLAY").ok();
     let guest_config = GuestConfiguration {
         command: Launch {
@@ -395,6 +396,7 @@ fn main() -> Result<ExitCode> {
         host_display: display,
         merged_rootfs: options.merged_rootfs,
         emulator: options.emulator,
+        cwd,
     };
     let mut muvm_config_file = NamedTempFile::new()
         .context("Failed to create a temporary file to store the muvm guest config")?;

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -21,6 +21,7 @@ pub struct Options {
     pub privileged: bool,
     pub publish_ports: Vec<String>,
     pub emulator: Option<Emulator>,
+    pub init_commands: Vec<PathBuf>,
     pub command: PathBuf,
     pub command_args: Vec<String>,
 }
@@ -132,6 +133,15 @@ pub fn options() -> OptionParser<Options> {
         )
         .argument::<String>("[[IP:][HOST_PORT]:]GUEST_PORT[/PROTOCOL]")
         .many();
+    let init_commands = long("execute-pre")
+        .short('x')
+        .help(
+            "Command to run inside the VM before guest server starts.
+            Can be used for e.g. setting up additional mounts.
+            Can be specified multiple times.",
+        )
+        .argument("COMMAND")
+        .many();
     let command = positional("COMMAND").help("the command you want to execute in the vm");
     let command_args = any::<String, _, _>("COMMAND_ARGS", |arg| {
         (!["--help", "-h"].contains(&&*arg)).then_some(arg)
@@ -152,6 +162,7 @@ pub fn options() -> OptionParser<Options> {
         privileged,
         publish_ports,
         emulator,
+        init_commands,
         // positionals
         command,
         command_args,

--- a/crates/muvm/src/config.rs
+++ b/crates/muvm/src/config.rs
@@ -1,0 +1,73 @@
+use std::{
+    env::{self, VarError},
+    io,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct Configuration {
+    pub execute_pre: Option<PathBuf>,
+}
+
+fn get_var_if_exists(name: &str) -> Option<Result<String>> {
+    match env::var(name) {
+        Ok(val) => Some(Ok(val)),
+        Err(VarError::NotPresent) => None,
+        Err(e) => Some(Err(e.into())),
+    }
+}
+
+fn get_user_config_path() -> Result<PathBuf> {
+    let mut path = get_var_if_exists("XDG_CONFIG_DIR").map_or_else(
+        || {
+            let base = env::var("HOME").context("Failed to get HOME")?;
+            let mut base = PathBuf::from(base);
+            base.push(".config");
+            Ok(base)
+        },
+        |p| p.map(PathBuf::from),
+    )?;
+    path.push("muvm");
+    path.push("config.json");
+    Ok(path)
+}
+
+fn get_global_config_path() -> Result<PathBuf> {
+    Ok(PathBuf::from("/etc/muvm/config.json"))
+}
+
+fn get_system_config_path() -> Result<PathBuf> {
+    Ok(PathBuf::from("/usr/lib/muvm/config.json"))
+}
+
+const CONFIG_PATHS: &[fn() -> Result<PathBuf>] = &[
+    get_user_config_path,
+    get_global_config_path,
+    get_system_config_path,
+];
+
+fn read_to_string_if_exists(p: &Path) -> Option<Result<String>> {
+    match std::fs::read_to_string(p) {
+        Ok(content) => Some(Ok(content)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => None,
+        Err(e) => Some(Err(e.into())),
+    }
+}
+
+impl Configuration {
+    pub fn parse_config_file() -> Result<Self> {
+        let Some(content) = CONFIG_PATHS.iter().find_map(|get_config_path| {
+            let config_path = match get_config_path() {
+                Ok(path) => path,
+                Err(e) => return Some(Err(e)),
+            };
+            read_to_string_if_exists(&config_path)
+        }) else {
+            return Ok(Default::default());
+        };
+        Ok(serde_json::from_str(&content?)?)
+    }
+}

--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -96,11 +96,7 @@ fn main() -> Result<()> {
 
     configure_network()?;
 
-    let run_path = match setup_user(
-        options.username,
-        Uid::from(options.uid),
-        Gid::from(options.gid),
-    ) {
+    let run_path = match setup_user(Uid::from(options.uid), Gid::from(options.gid)) {
         Ok(p) => p,
         Err(err) => return Err(err).context("Failed to set up user, bailing out"),
     };

--- a/crates/muvm/src/lib.rs
+++ b/crates/muvm/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli_options;
+pub mod config;
 pub mod cpu;
 pub mod env;
 pub mod hidpipe_common;

--- a/crates/muvm/src/utils/launch.rs
+++ b/crates/muvm/src/utils/launch.rs
@@ -44,6 +44,7 @@ pub struct GuestConfiguration {
     pub merged_rootfs: bool,
     pub emulator: Option<Emulator>,
     pub cwd: PathBuf,
+    pub init_commands: Vec<PathBuf>,
 }
 
 pub const PULSE_SOCKET: u32 = 3333;

--- a/crates/muvm/src/utils/launch.rs
+++ b/crates/muvm/src/utils/launch.rs
@@ -38,7 +38,6 @@ impl FromStr for Emulator {
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct GuestConfiguration {
     pub command: Launch,
-    pub username: String,
     pub uid: u32,
     pub gid: u32,
     pub host_display: Option<String>,

--- a/crates/muvm/src/utils/launch.rs
+++ b/crates/muvm/src/utils/launch.rs
@@ -43,6 +43,7 @@ pub struct GuestConfiguration {
     pub host_display: Option<String>,
     pub merged_rootfs: bool,
     pub emulator: Option<Emulator>,
+    pub cwd: PathBuf,
 }
 
 pub const PULSE_SOCKET: u32 = 3333;


### PR DESCRIPTION
Closes #37, supersedes #38 while being more general

Allows to execute a command before the guest server starts.
Useful on distros like NixOS where we need additional mounts.

E.g. on NixOS this means I can use muvm from main with this patch by running `muvm --init-command=init.sh $SHELL` with `init.sh` being
```sh
#!/bin/sh

ln -s /run/muvm-host/run/opengl-driver /run/opengl-driver
ln -s /run/muvm-host/run/current-system /run/current-system
```
whereas currently it's not as straightforward