### PR TITLE
Return early from parsing DHCP response if End is encoutered

### DIFF
--- a/crates/muvm/src/guest/net.rs
+++ b/crates/muvm/src/guest/net.rs
@@ -171,6 +171,12 @@ fn do_dhcp(rtnl: &NlRouter) -> Result<()> {
 
         while p < len {
             let o = msg[p];
+
+            if o == 0xff {
+                // Option 255: End (of options)
+                break;
+            }
+
             let l: u8 = msg[p + 1];
             p += 2; // Length doesn't include code and length field itself
 
@@ -195,9 +201,6 @@ fn do_dhcp(rtnl: &NlRouter) -> Result<()> {
 
                 // We don't know yet if IPv6 is available: don't go below 1280 B
                 mtu = mtu.clamp(1280, 65520);
-            } else if o == 0xff {
-                // Option 255: End (of options)
-                break;
             }
 
             p += l as usize;


### PR DESCRIPTION
Up until now DHCP response was parsed by reading the option and the length first. The length field obviously does not apply to the End option, so if muvm got a response that ended exactly at the End byte, muvm would crash because of an out-of-bound read.

This works with older versions of passt because the response muvm received was longer than it could've been. Latest version of passt sends only as many bytes as necessary.

cc @sbrivio-rh