### PR TITLE
Bump version 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "muvm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muvm"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Sergio Lopez <slp@redhat.com>", "Teoh Han Hui <teohhanhui@gmail.com>", "Sasha Finkelstein <fnkl.kernel@gmail.com>", "Asahi Lina <lina@asahilina.net>"]
 edition = "2021"
 rust-version = "1.80.0"


### PR DESCRIPTION
Prepare for an expedited minor release to address a crash when parsing a DHCP response from passt (see #168).