### PR TITLE
Set XDG_RUNTIME_DIR perimssions to 700

### DIFF
--- a/crates/muvm/src/guest/user.rs
+++ b/crates/muvm/src/guest/user.rs
@@ -16,7 +16,7 @@ pub fn setup_user(uid: Uid, gid: Gid) -> Result<PathBuf> {
 
     let path = tempfile::Builder::new()
         .prefix(&format!("muvm-run-{uid}-"))
-        .permissions(Permissions::from_mode(0o755))
+        .permissions(Permissions::from_mode(0o700))
         .tempdir()
         .context("Failed to create temp dir for `XDG_RUNTIME_DIR`")?
         .into_path();


### PR DESCRIPTION
The current behavior seems to date back to the initial commit of the original C version of this tool:

https://github.com/teohhanhui/krun.legacy/commit/01ae759737f4056977c26e269978c670fd13e918#diff-ba1f55157a5e8661da39884a2669de7c912ff94d98134d6d520ed0468670e39bR198

Is anything relying on this extra permissiveness? I didn't notice any breakage in a quick test after patching this (consisting of launching Balatro through steam, nevermind that I normally just use the native build of love to run balatro) but that doesn't mean much. 