### PR TITLE
Improved pipewire bridge support

### DIFF
--- a/crates/muvm/src/hidpipe_server.rs
+++ b/crates/muvm/src/hidpipe_server.rs
@@ -104,7 +104,7 @@ struct EvdevContainer {
     names_to_fds: HashMap<String, u64>,
 }
 
-fn insert_entry<K, V>(entry: hash_map::Entry<K, V>, v: V) -> &V {
+fn insert_entry<K, V>(entry: hash_map::Entry<'_, K, V>, v: V) -> &V {
     match entry {
         hash_map::Entry::Vacant(e) => e.insert(v),
         hash_map::Entry::Occupied(mut e) => {

--- a/crates/muvm/src/net.rs
+++ b/crates/muvm/src/net.rs
@@ -24,7 +24,7 @@ fn parse_range(r: &str) -> Result<(u32, u32)> {
 }
 
 impl PublishSpec<'_> {
-    fn parse(mut arg: &str) -> Result<PublishSpec> {
+    fn parse(mut arg: &str) -> Result<PublishSpec<'_>> {
         let mut udp = false;
         if arg.ends_with("/udp") {
             udp = true;


### PR DESCRIPTION
Linux version of Dota 2 includes a new enough version of SDL to have native pipewire support. Naturally it ends up using protocol features that the bridge did not support previously