### PR TITLE
Reduce bridge spamminess

### DIFF
--- a/crates/muvm/src/guest/bridge/pipewire.rs
+++ b/crates/muvm/src/guest/bridge/pipewire.rs
@@ -4,6 +4,7 @@ use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::{env, mem};
 
 use anyhow::Result;
+use log::debug;
 use nix::errno::Errno;
 use nix::sys::epoll::EpollFlags;
 use nix::sys::eventfd::{EfdFlags, EventFd};
@@ -235,7 +236,7 @@ impl ProtocolHandler for PipeWireProtocolHandler {
         resources: &mut VecDeque<CrossDomainResource>,
     ) -> Result<StreamRecvResult> {
         if data.len() < PipeWireHeader::SIZE {
-            eprintln!(
+            debug!(
                 "Pipewire message truncated (expected at least 16 bytes, got {})",
                 data.len(),
             );
@@ -274,7 +275,7 @@ impl ProtocolHandler for PipeWireProtocolHandler {
         data: &mut [u8],
     ) -> Result<StreamSendResult<Self::ResourceFinalizer>> {
         if data.len() < PipeWireHeader::SIZE {
-            eprintln!(
+            debug!(
                 "Pipewire message truncated (expected at least 16 bytes, got {})",
                 data.len(),
             );

--- a/crates/muvm/src/guest/bridge/x11.rs
+++ b/crates/muvm/src/guest/bridge/x11.rs
@@ -12,6 +12,7 @@ use std::thread::JoinHandle;
 use std::{fs, mem, ptr, thread};
 
 use anyhow::Result;
+use log::debug;
 use nix::errno::Errno;
 use nix::fcntl::readlink;
 use nix::libc::{
@@ -176,7 +177,7 @@ impl ProtocolHandler for X11ProtocolHandler {
             });
         }
         if data.len() < 32 {
-            eprintln!(
+            debug!(
                 "X11 message truncated (expected at least 32 bytes, got {})",
                 data.len(),
             );
@@ -227,7 +228,7 @@ impl ProtocolHandler for X11ProtocolHandler {
             });
         }
         if buf.len() < 4 {
-            eprintln!(
+            debug!(
                 "X11 message truncated (expected at least 4 bytes, got {})",
                 buf.len(),
             );
@@ -236,7 +237,7 @@ impl ProtocolHandler for X11ProtocolHandler {
         let mut req_len = u16::from_ne_bytes(buf[2..4].try_into().unwrap()) as usize * 4;
         if req_len == 0 {
             if buf.len() < 8 {
-                eprintln!(
+                debug!(
                     "X11 message truncated (expected at least 8 bytes, got {})",
                     buf.len(),
                 );

--- a/crates/muvm/src/hidpipe_server.rs
+++ b/crates/muvm/src/hidpipe_server.rs
@@ -104,7 +104,7 @@ struct EvdevContainer {
     names_to_fds: HashMap<String, u64>,
 }
 
-fn insert_entry<K, V>(entry: hash_map::Entry<K, V>, v: V) -> &V {
+fn insert_entry<K, V>(entry: hash_map::Entry<'_, K, V>, v: V) -> &V {
     match entry {
         hash_map::Entry::Vacant(e) => e.insert(v),
         hash_map::Entry::Occupied(mut e) => {

--- a/crates/muvm/src/net.rs
+++ b/crates/muvm/src/net.rs
@@ -24,7 +24,7 @@ fn parse_range(r: &str) -> Result<(u32, u32)> {
 }
 
 impl PublishSpec<'_> {
-    fn parse(mut arg: &str) -> Result<PublishSpec> {
+    fn parse(mut arg: &str) -> Result<PublishSpec<'_>> {
         let mut udp = false;
         if arg.ends_with("/udp") {
             udp = true;


### PR DESCRIPTION
Truncated messages are just a fact of life, we handle them correctly. Same for clients disconnecting with ECONNRESET, both were useful debug aids, but now they are just useless spam that can look like an error to an unknowing user.