### PR TITLE
Add a user init commands flag

### DIFF
--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -405,6 +405,7 @@ fn main() -> Result<ExitCode> {
         emulator: options.emulator,
         cwd,
         init_commands,
+        user_init_commands: options.user_init_commands,
     };
     let mut muvm_config_file = NamedTempFile::new()
         .context("Failed to create a temporary file to store the muvm guest config")?;

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -22,6 +22,7 @@ pub struct Options {
     pub publish_ports: Vec<String>,
     pub emulator: Option<Emulator>,
     pub init_commands: Vec<PathBuf>,
+    pub user_init_commands: Vec<PathBuf>,
     pub command: PathBuf,
     pub command_args: Vec<String>,
 }
@@ -136,8 +137,16 @@ pub fn options() -> OptionParser<Options> {
     let init_commands = long("execute-pre")
         .short('x')
         .help(
-            "Command to run inside the VM before guest server starts.
+            "Command to run inside the VM before guest server starts, while still running as root.
             Can be used for e.g. setting up additional mounts.
+            Can be specified multiple times.",
+        )
+        .argument("COMMAND")
+        .many();
+    let user_init_commands = long("user-execute-pre")
+        .short('X')
+        .help(
+            "Command to run inside the VM before guest server starts, but after the user is set up.
             Can be specified multiple times.",
         )
         .argument("COMMAND")
@@ -163,6 +172,7 @@ pub fn options() -> OptionParser<Options> {
         publish_ports,
         emulator,
         init_commands,
+        user_init_commands,
         // positionals
         command,
         command_args,

--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -111,6 +111,16 @@ fn main() -> Result<()> {
         Err(err) => return Err(err).context("Failed to set up user, bailing out"),
     };
 
+    for init_command in options.user_init_commands {
+        let code = Command::new(&init_command)
+            .current_dir(&options.cwd)
+            .spawn()?
+            .wait()?;
+        if !code.success() {
+            return Err(anyhow!("Executing `{}` failed", init_command.display()));
+        }
+    }
+
     let pulse_path = run_path.join("pulse");
     std::fs::create_dir(&pulse_path)
         .context("Failed to create `pulse` directory in `XDG_RUNTIME_DIR`")?;

--- a/crates/muvm/src/utils/launch.rs
+++ b/crates/muvm/src/utils/launch.rs
@@ -45,6 +45,7 @@ pub struct GuestConfiguration {
     pub emulator: Option<Emulator>,
     pub cwd: PathBuf,
     pub init_commands: Vec<PathBuf>,
+    pub user_init_commands: Vec<PathBuf>,
 }
 
 pub const PULSE_SOCKET: u32 = 3333;


### PR DESCRIPTION
Some custom init things (like spawning Wayland and D-Bus proxies) have to run **after** the user account has been set up and XDG_RUNTIME_DIR has been created and set. Let's simply add a big-X flag for executing things as the user?