### PR TITLE
guest/server: pass exit code back to pid1

### DIFF
--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::Read;
 use std::os::fd::AsFd;
 use std::panic::catch_unwind;
-use std::process::Command;
+use std::process::{Command, ExitCode};
 use std::{cmp, env, fs, thread};
 
 use anyhow::{anyhow, Context, Result};
@@ -23,12 +23,12 @@ use rustix::process::{getrlimit, setrlimit, Resource};
 
 const KRUN_CONFIG: &str = "KRUN_CONFIG";
 
-fn main() -> Result<()> {
+fn main() -> Result<ExitCode> {
     env_logger::init();
 
     if let Ok(val) = env::var("__X11BRIDGE_DEBUG") {
         start_x11bridge(val.parse()?);
-        return Ok(());
+        return Ok(ExitCode::SUCCESS);
     }
 
     let config_path = env::args()


### PR DESCRIPTION
libkrun's built-in init [supports reporting the exit code](https://github.com/containers/libkrun/blob/bea9fef79480a2149a7f096cf3d05c106b9c3ed4/init/init.c#L1238-L1244) back to the host from the program it launches. Let's not break the chain here!