### PR TITLE
Add support for running a custom init (including systemd)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "listenfd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87bc54a4629b4294d0b3ef041b64c40c611097a677d9dc07b2c67739fe39dba"
+dependencies = [
+ "libc",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +580,7 @@ dependencies = [
  "input-linux",
  "input-linux-sys",
  "krun-sys",
+ "listenfd",
  "log",
  "neli",
  "nix 0.30.1",
@@ -1068,6 +1080,28 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "listenfd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87bc54a4629b4294d0b3ef041b64c40c611097a677d9dc07b2c67739fe39dba"
+dependencies = [
+ "libc",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +580,7 @@ dependencies = [
  "input-linux",
  "input-linux-sys",
  "krun-sys",
+ "listenfd",
  "log",
  "neli",
  "nix 0.30.1",
@@ -1061,6 +1073,28 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1.38.0", default-features = false, features = ["io-util", "
 tokio-stream = { version = "0.1.15", default-features = false, features = ["net", "sync"] }
 udev = { version = "0.9.0", default-features = false, features = [] }
 uuid = { version = "1.10.0", default-features = false, features = ["serde", "std", "v7"] }
+listenfd = "1.0.2"
 
 [[bin]]
 name = "muvm"

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.38.0", default-features = false, features = ["io-util", "
 tokio-stream = { version = "0.1.15", default-features = false, features = ["net", "sync"] }
 udev = { version = "0.9.0", default-features = false, features = [] }
 uuid = { version = "1.10.0", default-features = false, features = ["serde", "std", "v7"] }
+listenfd = "1.0.2"
 
 [[bin]]
 name = "muvm"

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -478,9 +478,19 @@ fn main() -> Result<ExitCode> {
 
     let krun_config_env = CString::new(format!("KRUN_CONFIG={}", config_file.path().display()))
         .context("Failed to process config_file var as it contains NUL character")?;
+    #[allow(unused_assignments)] // wat?
+    let mut muvm_config_env = None; // keep in this scope
     let mut env: Vec<*const c_char> = vec![krun_config_env.as_ptr()];
     if custom_init {
         env.push(c"KRUN_INIT_PID1=1".as_ptr());
+        muvm_config_env = Some(
+            CString::new(format!(
+                "MUVM_REMOTE_CONFIG={}",
+                muvm_config_file.path().display()
+            ))
+            .context("Failed to process internal config path as it contains NUL character")?,
+        );
+        env.push(muvm_config_env.as_ref().unwrap().as_ptr());
     }
     env.push(std::ptr::null());
 

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -429,13 +429,21 @@ fn main() -> Result<ExitCode> {
         .to_str()
         .context("Temporary directory path contains invalid UTF-8")?
         .to_owned();
-    let muvm_guest_args = vec![
-        muvm_guest_path
-            .to_str()
-            .context("Failed to process `muvm-guest` path as it contains invalid UTF-8")?
-            .to_owned(),
-        muvm_config_path,
-    ];
+    let custom_init = options.custom_init_cmdline.is_some();
+    let muvm_guest_args = if let Some(cmdline) = options.custom_init_cmdline {
+        cmdline
+            .split_whitespace()
+            .map(|a| a.to_owned())
+            .collect::<Vec<String>>()
+    } else {
+        vec![
+            muvm_guest_path
+                .to_str()
+                .context("Failed to process `muvm-guest` path as it contains invalid UTF-8")?
+                .to_owned(),
+            muvm_config_path,
+        ]
+    };
 
     // And forward XAUTHORITY. This will be modified to fix the
     // display name in muvm-guest.
@@ -470,7 +478,11 @@ fn main() -> Result<ExitCode> {
 
     let krun_config_env = CString::new(format!("KRUN_CONFIG={}", config_file.path().display()))
         .context("Failed to process config_file var as it contains NUL character")?;
-    let env: Vec<*const c_char> = vec![krun_config_env.as_ptr(), std::ptr::null()];
+    let mut env: Vec<*const c_char> = vec![krun_config_env.as_ptr()];
+    if custom_init {
+        env.push(c"KRUN_INIT_PID1=1".as_ptr());
+    }
+    env.push(std::ptr::null());
 
     {
         // Sets environment variables to be configured in the context of the executable.

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -47,6 +47,7 @@ pub struct Options {
     pub emulator: Option<Emulator>,
     pub init_commands: Vec<PathBuf>,
     pub user_init_commands: Vec<PathBuf>,
+    pub custom_init_cmdline: Option<String>,
     pub command: PathBuf,
     pub command_args: Vec<String>,
 }
@@ -179,6 +180,13 @@ pub fn options() -> OptionParser<Options> {
         )
         .argument("COMMAND")
         .many();
+    let custom_init_cmdline = long("custom-init-cmdline")
+        .help(
+            "Command and arguments to run as PID 1, replacing muvm's own init.
+            (Warning: this will break many muvm features, unless your init reimplements them.)",
+        )
+        .argument("CMDLINE")
+        .optional();
     let command = positional("COMMAND").help("the command you want to execute in the vm");
     let command_args = any::<String, _, _>("COMMAND_ARGS", |arg| {
         (!["--help", "-h"].contains(&&*arg)).then_some(arg)
@@ -202,6 +210,7 @@ pub fn options() -> OptionParser<Options> {
         emulator,
         init_commands,
         user_init_commands,
+        custom_init_cmdline,
         // positionals
         command,
         command_args,

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -48,6 +48,7 @@ pub struct Options {
     pub emulator: Option<Emulator>,
     pub init_commands: Vec<PathBuf>,
     pub user_init_commands: Vec<PathBuf>,
+    pub custom_init_cmdline: Option<String>,
     pub command: PathBuf,
     pub command_args: Vec<String>,
 }
@@ -189,6 +190,13 @@ pub fn options() -> OptionParser<Options> {
         )
         .argument("COMMAND")
         .many();
+    let custom_init_cmdline = long("custom-init-cmdline")
+        .help(
+            "Command and arguments to run as PID 1, replacing muvm's own init.
+            (Warning: this will break many muvm features, unless your init reimplements them.)",
+        )
+        .argument("CMDLINE")
+        .optional();
     let command = positional("COMMAND").help("the command you want to execute in the vm");
     let command_args = any::<String, _, _>("COMMAND_ARGS", |arg| {
         (!["--help", "-h"].contains(&&*arg)).then_some(arg)
@@ -213,6 +221,7 @@ pub fn options() -> OptionParser<Options> {
         emulator,
         init_commands,
         user_init_commands,
+        custom_init_cmdline,
         // positionals
         command,
         command_args,

--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context, Result};
 use muvm::guest::box64::setup_box;
 use muvm::guest::bridge::common::{bridge_loop, bridge_loop_with_listenfd};
 use muvm::guest::bridge::pipewire::{pipewire_sock_path, PipeWireProtocolHandler};
-use muvm::guest::bridge::x11::start_x11bridge;
+use muvm::guest::bridge::x11::{start_x11bridge, X11ProtocolHandler};
 use muvm::guest::fex::setup_fex;
 use muvm::guest::hidpipe::start_hidpipe;
 use muvm::guest::mount::mount_filesystems;
@@ -36,6 +36,10 @@ fn main() -> Result<ExitCode> {
         "muvm-pwbridge" => {
             bridge_loop_with_listenfd::<PipeWireProtocolHandler>(pipewire_sock_path);
             return Ok(());
+        },
+        "muvm-x11bridge" => {
+            bridge_loop_with_listenfd::<X11ProtocolHandler>(|| "/tmp/.X11-unix/X1".to_owned());
+            return Ok(ExitCode::SUCCESS);
         },
         "muvm-remote" => {
             let rt = tokio::runtime::Runtime::new().unwrap();

--- a/crates/muvm/src/guest/bin/muvm-guest.rs
+++ b/crates/muvm/src/guest/bin/muvm-guest.rs
@@ -41,6 +41,14 @@ fn main() -> Result<ExitCode> {
             bridge_loop_with_listenfd::<X11ProtocolHandler>(|| "/tmp/.X11-unix/X1".to_owned());
             return Ok(ExitCode::SUCCESS);
         },
+        "muvm-hidpipe" => {
+            let config_path =
+                env::var("MUVM_REMOTE_CONFIG").context("expected MUVM_REMOTE_CONFIG to be set")?;
+            let options = parse_config(config_path)?;
+            let uid = options.uid;
+            start_hidpipe(uid);
+            return Ok(ExitCode::SUCCESS);
+        },
         "muvm-remote" => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             let mut command_args = env::args().skip(1);

--- a/crates/muvm/src/guest/bridge/common.rs
+++ b/crates/muvm/src/guest/bridge/common.rs
@@ -971,10 +971,24 @@ impl<'a, T: ProtocolHandler> SubPoll<'a, T> {
     }
 }
 
+pub fn bridge_loop_with_listenfd<T: ProtocolHandler>(fallback_sock_path: impl Fn() -> String) {
+    if let Some(listen_sock) = listenfd::ListenFd::from_env()
+        .take_unix_listener(0)
+        .unwrap()
+    {
+        bridge_loop_sock::<T>(listen_sock)
+    } else {
+        bridge_loop::<T>(&fallback_sock_path())
+    }
+}
+
 pub fn bridge_loop<T: ProtocolHandler>(sock_path: &str) {
-    let epoll = Epoll::new(EpollCreateFlags::empty()).unwrap();
     _ = fs::remove_file(sock_path);
-    let listen_sock = UnixListener::bind(sock_path).unwrap();
+    bridge_loop_sock::<T>(UnixListener::bind(sock_path).unwrap());
+}
+
+pub fn bridge_loop_sock<T: ProtocolHandler>(listen_sock: UnixListener) {
+    let epoll = Epoll::new(EpollCreateFlags::empty()).unwrap();
     epoll
         .add(
             &listen_sock,

--- a/crates/muvm/src/guest/bridge/pipewire.rs
+++ b/crates/muvm/src/guest/bridge/pipewire.rs
@@ -9,7 +9,6 @@ use nix::errno::Errno;
 use nix::sys::epoll::EpollFlags;
 use nix::sys::eventfd::{EfdFlags, EventFd};
 
-use crate::guest::bridge::common;
 use crate::guest::bridge::common::{
     Client, CrossDomainHeader, CrossDomainResource, GemHandleFinalizer, MessageResourceFinalizer,
     ProtocolHandler, StreamRecvResult, StreamSendResult,
@@ -166,7 +165,7 @@ impl PipeWireHeader {
     }
 }
 
-enum PipeWireResourceFinalizer {
+pub enum PipeWireResourceFinalizer {
     Gem(GemHandleFinalizer),
 }
 
@@ -199,7 +198,7 @@ impl ClientNodeData {
     }
 }
 
-struct PipeWireProtocolHandler {
+pub struct PipeWireProtocolHandler {
     client_nodes: HashMap<u32, ClientNodeData>,
     guest_to_host_eventfds: HashMap<u64, CrossDomainEventFd>,
     host_to_guest_eventfds: HashMap<u32, CrossDomainEventFd>,
@@ -434,8 +433,6 @@ impl ProtocolHandler for PipeWireProtocolHandler {
     }
 }
 
-pub fn start_pwbridge() {
-    let sock_path = format!("{}/pipewire-0", env::var("XDG_RUNTIME_DIR").unwrap());
-
-    common::bridge_loop::<PipeWireProtocolHandler>(&sock_path)
+pub fn pipewire_sock_path() -> String {
+    format!("{}/pipewire-0", env::var("XDG_RUNTIME_DIR").unwrap())
 }

--- a/crates/muvm/src/guest/bridge/pipewire.rs
+++ b/crates/muvm/src/guest/bridge/pipewire.rs
@@ -9,7 +9,6 @@ use nix::errno::Errno;
 use nix::sys::epoll::EpollFlags;
 use nix::sys::eventfd::{EfdFlags, EventFd};
 
-use crate::guest::bridge::common;
 use crate::guest::bridge::common::{
     Client, CrossDomainHeader, CrossDomainResource, GemHandleFinalizer, MessageResourceFinalizer,
     ProtocolHandler, StreamRecvResult, StreamSendResult,
@@ -166,7 +165,7 @@ impl PipeWireHeader {
     }
 }
 
-enum PipeWireResourceFinalizer {
+pub enum PipeWireResourceFinalizer {
     Gem(GemHandleFinalizer),
 }
 
@@ -199,7 +198,7 @@ impl ClientNodeData {
     }
 }
 
-struct PipeWireProtocolHandler {
+pub struct PipeWireProtocolHandler {
     client_nodes: HashMap<u32, ClientNodeData>,
     guest_to_host_eventfds: HashMap<u64, CrossDomainEventFd>,
     host_to_guest_eventfds: HashMap<u32, CrossDomainEventFd>,
@@ -438,8 +437,6 @@ impl ProtocolHandler for PipeWireProtocolHandler {
     }
 }
 
-pub fn start_pwbridge() {
-    let sock_path = format!("{}/pipewire-0", env::var("XDG_RUNTIME_DIR").unwrap());
-
-    common::bridge_loop::<PipeWireProtocolHandler>(&sock_path)
+pub fn pipewire_sock_path() -> String {
+    format!("{}/pipewire-0", env::var("XDG_RUNTIME_DIR").unwrap())
 }

--- a/crates/muvm/src/guest/bridge/x11.rs
+++ b/crates/muvm/src/guest/bridge/x11.rs
@@ -155,7 +155,7 @@ struct CrossDomainFutexDestroy {
     pad: u32,
 }
 
-enum X11ResourceFinalizer {
+pub enum X11ResourceFinalizer {
     Gem(GemHandleFinalizer),
     Futex(u32),
 }
@@ -186,7 +186,7 @@ impl MessageResourceFinalizer for X11ResourceFinalizer {
     }
 }
 
-struct X11ProtocolHandler {
+pub struct X11ProtocolHandler {
     // futex_watchers gets dropped first
     futex_watchers: HashMap<u32, FutexWatcherThread>,
     got_first_req: bool,

--- a/crates/muvm/src/guest/bridge/x11.rs
+++ b/crates/muvm/src/guest/bridge/x11.rs
@@ -4,7 +4,6 @@ use std::ffi::{c_long, c_void, CString};
 use std::fs::{read_to_string, remove_file, File};
 use std::io::{IoSlice, Write};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
-use std::process::exit;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -714,7 +713,7 @@ impl RemoteCaller {
 
         // Find the vDSO and the address of a syscall instruction within it
         let (vdso_start, _) = find_vdso(Some(pid))?;
-        let syscall_addr = vdso_start + SYSCALL_OFFSET.get().unwrap();
+        let syscall_addr = vdso_start + SYSCALL_OFFSET.get_or_init(find_syscall_offset);
 
         let mut regs = old_regs;
         arch::set_syscall_addr(&mut regs, syscall_addr);
@@ -857,9 +856,7 @@ fn find_vdso(pid: Option<Pid>) -> Result<(usize, usize), Errno> {
     Err(Errno::EINVAL)
 }
 
-pub fn start_x11bridge(display: u32) {
-    let sock_path = format!("/tmp/.X11-unix/X{display}");
-
+fn find_syscall_offset() -> usize {
     // Look for a syscall instruction in the vDSO. We assume all processes map
     // the same vDSO (which should be true if they are running under the same
     // kernel!)
@@ -868,14 +865,13 @@ pub fn start_x11bridge(display: u32) {
         let addr = vdso_start + off;
         let val = unsafe { std::ptr::read(addr as *const arch::SyscallInstr) };
         if val == arch::SYSCALL_INSTR {
-            SYSCALL_OFFSET.set(off).unwrap();
-            break;
+            return off;
         }
     }
-    if SYSCALL_OFFSET.get().is_none() {
-        eprintln!("Failed to find syscall instruction in vDSO");
-        exit(1);
-    }
+    panic!("Failed to find syscall instruction in vDSO");
+}
 
+pub fn start_x11bridge(display: u32) {
+    let sock_path = format!("/tmp/.X11-unix/X{display}");
     common::bridge_loop::<X11ProtocolHandler>(&sock_path)
 }


### PR DESCRIPTION
..yeah, you might say that this has really gone off the rails :) but we want to be able to ship apps with background services, configured the usual nix way just like on the host (which means systemd units are used to make them run).

Since https://github.com/containers/libkrun/pull/424 libkrun can run a custom init as PID 1, so now we can run systemd. It turned out to be quite easy to "disaggregate" muvm-guest into separate services that systemd can manage.. well, separately. Here I made it work like a busybox-style "mega binary" where what it does depends on what it's called as (`argv[0]`). I haven't yet added *all* the services, but I've already included pwbridge here as an example of supporting socket activation.

[muvm-systemd-pwb.av1.webm](https://github.com/user-attachments/assets/9bc63e65-2387-4f5d-a093-356845646b3f)

fun fact: I only found #201 because I went to implement this. :) and I did replicate that feature in systemd:

```ini
[Unit]
OnFailure=exit.target
OnSuccess=exit.target

[Service]
Type=exec
ExecStart=/opt/bin/muvm-remote /run/current-system/sw/bin/bash
ExecStopPost=+/nix/store/i0g30z11viax2v3ynm3p1411c4dhi6w8-python3-3.12.10-env/bin/python -c "import os,fcntl,struct;fcntl.ioctl(os.open('/', os.O_RDONLY), 0x7602, int(os.getenv('EXIT_STATUS', '1')))"
User=appvm
Group=appvm
StandardError=tty
StandardInput=tty
StandardOutput=tty
TTYPath=/dev/hvc0
```