### PR TITLE
Create $XDG_RUNTIME_DIR in /run/user/{uid}

### DIFF
--- a/crates/muvm/src/utils/fs.rs
+++ b/crates/muvm/src/utils/fs.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::os::unix::fs::PermissionsExt as _;
+use std::os::unix::fs::{DirBuilderExt as _, PermissionsExt as _};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -24,4 +24,11 @@ where
     }
 
     Ok(None)
+}
+
+pub fn mkdir_mode<P: AsRef<Path>>(path: P, mode: u32) -> Result<()> {
+    fs::DirBuilder::new()
+        .mode(mode)
+        .create(&path)
+        .with_context(|| format!("Failed to create {:?}", path.as_ref()))
 }


### PR DESCRIPTION
Using tempfile::Builder::tempdir() defaults to creating this directory in /tmp, which is shared with the host and often somewhat persistent. This causes one extra directory to be created in the host /tmp every time muvm runs.

Since we mount /run as a tmpfs now in the guest now, just create $XDG_RUNTIME_DIR in /run/user/{uid}, a common default. Specifically:

- Create /run/user as 0o755 (rwxr-xr-x) owned by root:root
- Create /run/user/{uid} as 0o700 (rwx------) owned by uid:gid