### PR TITLE
muvm: add container mode and passt sandbox policy controls

### DIFF
--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -15,7 +15,7 @@ use krun_sys::{
     VIRGLRENDERER_USE_ASYNC_FENCE_CB, VIRGLRENDERER_USE_EGL, VIRGLRENDERER_VENUS,
 };
 use log::debug;
-use muvm::cli_options::options;
+use muvm::cli_options::{options, PasstSandboxPolicy};
 use muvm::config::Configuration;
 use muvm::cpu::{get_fallback_cores, get_performance_cores};
 use muvm::env::{find_muvm_exec, prepare_env_vars};
@@ -75,6 +75,14 @@ fn main() -> Result<ExitCode> {
     }
 
     let options = options().fallback_to_usage().run();
+    let disable_hid = options.no_hid || options.container_mode;
+    let passt_policy = options
+        .passt_sandbox_policy
+        .unwrap_or(if options.container_mode {
+            PasstSandboxPolicy::Silent
+        } else {
+            PasstSandboxPolicy::Warn
+        });
     let config = Configuration::parse_config_file()?;
 
     let mut init_commands = options.init_commands;
@@ -278,7 +286,7 @@ fn main() -> Result<ExitCode> {
                 .context("Failed to connect to `passt`")?
                 .into()
         } else {
-            start_passt(&options.publish_ports)
+            start_passt(&options.publish_ports, passt_policy)
                 .context("Failed to start `passt`")?
                 .into()
         };
@@ -308,20 +316,22 @@ fn main() -> Result<ExitCode> {
             }
         }
 
-        let hidpipe_path = Path::new(&run_path).join("hidpipe");
-        spawn_hidpipe_server(hidpipe_path.clone()).context("Failed to spawn hidpipe thread")?;
-        let hidpipe_path = CString::new(
-            hidpipe_path
-                .to_str()
-                .expect("hidpipe_path should not contain invalid UTF-8"),
-        )
-        .context("Failed to process `hidpipe` path as it contains NUL character")?;
+        if !disable_hid {
+            let hidpipe_path = Path::new(&run_path).join("hidpipe");
+            spawn_hidpipe_server(hidpipe_path.clone()).context("Failed to spawn hidpipe thread")?;
+            let hidpipe_path = CString::new(
+                hidpipe_path
+                    .to_str()
+                    .expect("hidpipe_path should not contain invalid UTF-8"),
+            )
+            .context("Failed to process `hidpipe` path as it contains NUL character")?;
 
-        // SAFETY: `hidpipe_path` is a pointer to a `CString` with long enough lifetime.
-        let err = unsafe { krun_add_vsock_port(ctx_id, HIDPIPE_SOCKET, hidpipe_path.as_ptr()) };
-        if err < 0 {
-            let err = Errno::from_raw_os_error(-err);
-            return Err(err).context("Failed to configure vsock for hidpipe socket");
+            // SAFETY: `hidpipe_path` is a pointer to a `CString` with long enough lifetime.
+            let err = unsafe { krun_add_vsock_port(ctx_id, HIDPIPE_SOCKET, hidpipe_path.as_ptr()) };
+            if err < 0 {
+                let err = Errno::from_raw_os_error(-err);
+                return Err(err).context("Failed to configure vsock for hidpipe socket");
+            }
         }
 
         let socket_dir = Path::new(&run_path).join("krun/socket");

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -7,6 +7,25 @@ use bpaf::{any, construct, long, positional, OptionParser, Parser};
 use crate::types::MiB;
 use crate::utils::launch::Emulator;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PasstSandboxPolicy {
+    Warn,
+    Strict,
+    Silent,
+}
+
+impl std::str::FromStr for PasstSandboxPolicy {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s {
+            "warn" => Ok(Self::Warn),
+            "strict" => Ok(Self::Strict),
+            "silent" => Ok(Self::Silent),
+            x => Err(format!("Expected warn|strict|silent, got '{x}'")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum GpuMode {
     #[default]
@@ -42,6 +61,9 @@ pub struct Options {
     pub interactive: bool,
     pub tty: bool,
     pub privileged: bool,
+    pub no_hid: bool,
+    pub container_mode: bool,
+    pub passt_sandbox_policy: Option<PasstSandboxPolicy>,
     pub gpu_mode: Option<GpuMode>,
     pub publish_ports: Vec<String>,
     pub emulator: Option<Emulator>,
@@ -149,6 +171,23 @@ pub fn options() -> OptionParser<Options> {
         This notably does not allow root access to the host fs.",
         )
         .switch();
+    let no_hid = long("no-hid").help("Disable HID device emulation").switch();
+    let container_mode = long("container-mode")
+        .help(
+            "Container-friendly defaults.
+            Implies --no-hid.
+            Also defaults --passt-sandbox-policy to 'silent' unless explicitly set.",
+        )
+        .switch();
+    let passt_sandbox_policy = long("passt-sandbox-policy")
+        .help(
+            "How to handle passt sandbox downgrade when starting passt internally:
+            warn   (default): print passt warnings to stderr and continue
+            strict: fail if passt doesn't enter a separate user namespace
+            silent: suppress passt warnings and continue",
+        )
+        .argument::<PasstSandboxPolicy>("warn|strict|silent")
+        .optional();
     let gpu_mode = long("gpu-mode")
         .help("Use the given GPU virtualization method")
         .argument::<GpuMode>("drm|venus|software")
@@ -197,6 +236,9 @@ pub fn options() -> OptionParser<Options> {
         interactive,
         tty,
         privileged,
+        no_hid,
+        container_mode,
+        passt_sandbox_policy,
         gpu_mode,
         publish_ports,
         emulator,

--- a/crates/muvm/src/net.rs
+++ b/crates/muvm/src/net.rs
@@ -1,17 +1,55 @@
 use std::os::fd::{AsRawFd, IntoRawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Child, Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use log::debug;
 use rustix::io::dup;
+
+use crate::cli_options::PasstSandboxPolicy;
 
 struct PublishSpec<'a> {
     udp: bool,
     guest_range: (u32, u32),
     host_range: (u32, u32),
     ip: &'a str,
+}
+
+fn ensure_passt_userns(child: &mut Child) -> Result<()> {
+    let host_userns =
+        std::fs::read_link("/proc/self/ns/user").context("Failed to read /proc/self/ns/user")?;
+    let pid = child.id();
+    let child_userns_path = format!("/proc/{pid}/ns/user");
+    let deadline = Instant::now() + Duration::from_secs(1);
+
+    while Instant::now() < deadline {
+        if let Some(status) = child
+            .try_wait()
+            .context("Failed to query `passt` process state")?
+        {
+            return Err(anyhow!(
+                "`passt` exited before sandbox check completed with status {status}"
+            ));
+        }
+
+        match std::fs::read_link(&child_userns_path) {
+            Ok(ns) if ns != host_userns => return Ok(()),
+            Ok(_) => {},
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {},
+            Err(e) => return Err(e).context("Failed to read child user namespace"),
+        }
+
+        sleep(Duration::from_millis(25));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    Err(anyhow!(
+        "`passt` failed strict sandbox policy: no separate user namespace was established"
+    ))
 }
 
 fn parse_range(r: &str) -> Result<(u32, u32)> {
@@ -82,7 +120,10 @@ where
     Ok(UnixStream::connect(passt_socket_path)?)
 }
 
-pub fn start_passt(publish_ports: &[String]) -> Result<UnixStream> {
+pub fn start_passt(
+    publish_ports: &[String],
+    passt_sandbox_policy: PasstSandboxPolicy,
+) -> Result<UnixStream> {
     // SAFETY: The child process should not inherit the file descriptor of
     // `parent_socket`. There is no documented guarantee of this, but the
     // implementation as of writing atomically sets `SOCK_CLOEXEC`.
@@ -104,6 +145,9 @@ pub fn start_passt(publish_ports: &[String]) -> Result<UnixStream> {
     debug!(fd = child_fd.as_raw_fd(); "passing fd to passt");
 
     let mut cmd = Command::new("passt");
+    if passt_sandbox_policy != PasstSandboxPolicy::Warn {
+        cmd.stderr(Stdio::null());
+    }
     // SAFETY: `child_fd` is an `OwnedFd` and consumed to prevent closing on drop,
     // as it will now be owned by the child process.
     // See https://doc.rust-lang.org/std/io/index.html#io-safety
@@ -112,9 +156,11 @@ pub fn start_passt(publish_ports: &[String]) -> Result<UnixStream> {
     for spec in publish_ports {
         cmd.args(PublishSpec::parse(spec)?.to_args());
     }
-    let child = cmd.spawn();
-    if let Err(err) = child {
-        return Err(err).context("Failed to execute `passt` as child process");
+    let mut child = cmd
+        .spawn()
+        .context("Failed to execute `passt` as child process")?;
+    if passt_sandbox_policy == PasstSandboxPolicy::Strict {
+        ensure_passt_userns(&mut child).context("`passt` sandbox policy check failed")?;
     }
 
     Ok(parent_socket)


### PR DESCRIPTION
## Background

When running `muvm` in a container environment, two common problems arise:

1. `hidpipe` depends on the host input device and is often unavailable within the container;

2. `passt` experiences sandbox degradation in containers with limited user namespaces, and its current behavior is not sufficiently controllable.

## Changes

We hope to add the following capabilities:

- Add `--no-hid`

- Disable HID device emulation paths, skipping hidpipe initialization.

- Added `--container-mode`

- Container-friendly default:

- Implicitly enable `--no-hid`

- If no passt policy is explicitly specified, default to `silent`

- Added `--passt-sandbox-policy=warn|strict|silent`

- `warn`: Preserve warnings and continue (default)

- `silent`: Suppress passt sandbox degradation warnings and continue

- `strict`: Require passt to enter an independent user namespace; otherwise, fail fast.

## Strict Policy Implementation Description

`strict` does not rely on log text for judgment, but directly checks the namespace:

- After starting passt, read `/proc/self/ns/user` and `/proc/<passt_pid>/ns/user`

- Poll for a maximum of 1 second

- If an independent user namespace is not entered, terminate passt and return an error.

## Compatibility

- Default behavior remains compatible (the original logic applies when no new parameters are used)

- `--container-mode` only takes effect when explicitly used

## Affected Files

- `crates/muvm/src/cli_options.rs`

- `crates/muvm/src/bin/muvm.rs`

- `crates/muvm/src/net.rs`