### PR TITLE
muvm: Add a --passt-args argument to pass args to passt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "rustix 0.38.34",
  "serde",
  "serde_json",
+ "shell-words",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -896,6 +897,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -24,6 +24,7 @@ procfs = { version = "0.18.0", default-features = false, features = [] }
 rustix = { version = "0.38.34", default-features = false, features = ["fs", "mount", "process", "pty", "std", "stdio", "system", "termios", "use-libc-auxv"] }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.117", default-features = false, features = ["std"] }
+shell-words = { version = "1.1.1", default-features = false, features = ["std"] }
 tempfile = { version = "3.10.1", default-features = false, features = [] }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util", "macros", "net", "process", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1.15", default-features = false, features = ["net", "sync"] }

--- a/crates/muvm/src/bin/muvm.rs
+++ b/crates/muvm/src/bin/muvm.rs
@@ -278,7 +278,7 @@ fn main() -> Result<ExitCode> {
                 .context("Failed to connect to `passt`")?
                 .into()
         } else {
-            start_passt(&options.publish_ports)
+            start_passt(&options.publish_ports, &options.passt_args)
                 .context("Failed to start `passt`")?
                 .into()
         };

--- a/crates/muvm/src/cli_options.rs
+++ b/crates/muvm/src/cli_options.rs
@@ -37,6 +37,7 @@ pub struct Options {
     pub mem: Option<MiB>,
     pub vram: Option<MiB>,
     pub passt_socket: Option<PathBuf>,
+    pub passt_args: Vec<String>,
     pub fex_images: Vec<String>,
     pub merged_rootfs: bool,
     pub interactive: bool,
@@ -135,6 +136,15 @@ pub fn options() -> OptionParser<Options> {
         .help("Instead of starting passt, connect to passt socket at PATH")
         .argument("PATH")
         .optional();
+    let passt_args = long("passt-args")
+        .help(
+            "When starting passt, append the given arguments.
+            May contain shell-quoted args, like so: --passt-args '-l \"my log file.txt\"'",
+        )
+        .argument::<String>("ARGS")
+        .parse(|s| shell_words::split(&s))
+        .many()
+        .map(|nested| nested.into_iter().flatten().collect());
     let interactive = long("interactive")
         .short('i')
         .help("Attach to the command's stdin/out after starting it")
@@ -192,6 +202,7 @@ pub fn options() -> OptionParser<Options> {
         mem,
         vram,
         passt_socket,
+        passt_args,
         fex_images,
         merged_rootfs,
         interactive,

--- a/crates/muvm/src/net.rs
+++ b/crates/muvm/src/net.rs
@@ -82,7 +82,7 @@ where
     Ok(UnixStream::connect(passt_socket_path)?)
 }
 
-pub fn start_passt(publish_ports: &[String]) -> Result<UnixStream> {
+pub fn start_passt(publish_ports: &[String], passt_args: &[String]) -> Result<UnixStream> {
     // SAFETY: The child process should not inherit the file descriptor of
     // `parent_socket`. There is no documented guarantee of this, but the
     // implementation as of writing atomically sets `SOCK_CLOEXEC`.
@@ -111,6 +111,9 @@ pub fn start_passt(publish_ports: &[String]) -> Result<UnixStream> {
         .arg(format!("{}", child_fd.into_raw_fd()));
     for spec in publish_ports {
         cmd.args(PublishSpec::parse(spec)?.to_args());
+    }
+    for arg in passt_args {
+        cmd.arg(arg);
     }
     let child = cmd.spawn();
     if let Err(err) = child {


### PR DESCRIPTION
Sometimes it's necessary to pass additional args (such as the network interface) to passt. It's already been possible to spawn passt externally and give muvm its socket, but that's inconvenient especially when one wants to keep using the nicer muvm syntax for the exposed ports.