### PR TITLE
Update const-str dependency to v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,9 +191,9 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "const-str"
-version = "0.6.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e991226a70654b49d34de5ed064885f0bef0348a8e70018b8ff1ac80aa984a2"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
 
 [[package]]
 name = "darling"

--- a/crates/muvm/Cargo.toml
+++ b/crates/muvm/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 anyhow = { version = "1.0.82", default-features = false, features = ["std"] }
 bpaf = { version = "0.9.11", default-features = false, features = [] }
 byteorder = { version = "1.5.0", default-features = false, features = ["std"] }
-const-str = { version = "0.6.2", default-features = false, features = [] }
+const-str = { version = "1.1.0", default-features = false, features = [] }
 env_logger = { version = "0.11.8", default-features = false, features = ["auto-color", "humantime", "kv"] }
 input-linux = { version = "0.7.0", default-features = false, features = [] }
 input-linux-sys = { version = "0.9.0", default-features = false, features = [] }


### PR DESCRIPTION
`cargo test --workspace` still passes

(Motivated by https://src.fedoraproject.org/rpms/rust-const-str/pull-request/1 downstream in Fedora)