### PR TITLE
x11bridge: tolerate redundant GEM close for multi-plane DRI3 buffers

### DIFF
--- a/crates/muvm/src/guest/bridge/common.rs
+++ b/crates/muvm/src/guest/bridge/common.rs
@@ -479,6 +479,9 @@ pub struct Client<'a, P: ProtocolHandler> {
     debug_loop: DebugLoop,
     pub send_queue: VecDeque<SendPacket>,
     pub sub_poll: SubPoll<'a, P>,
+    /// Live GemHandleFinalizers per GEM handle. Multi-plane / same-BO DRI3 buffers
+    /// dedup several fds to one handle, so we refcount and close only on the last.
+    gem_handle_refs: HashMap<u32, u32>,
 }
 
 #[derive(Debug)]
@@ -493,6 +496,16 @@ pub struct GemHandleFinalizer(u32);
 
 impl GemHandleFinalizer {
     pub fn finalize<T: ProtocolHandler>(self, client: &mut Client<T>) -> Result<()> {
+        // Several fds can dedup to one handle (multi-plane / same-BO buffers), so a
+        // finalizer per fd would close it more than once -- EINVAL/ENOENT, tearing
+        // down the client. Close only on the last reference; real errors then matter.
+        if let Some(refs) = client.gem_handle_refs.get_mut(&self.0) {
+            if *refs > 1 {
+                *refs -= 1;
+                return Ok(());
+            }
+            client.gem_handle_refs.remove(&self.0);
+        }
         // SAFETY: we own self.0
         unsafe {
             let close = DrmGemClose::new(self.0);
@@ -520,6 +533,7 @@ impl<'a, P: ProtocolHandler> Client<'a, P> {
             debug_loop: DebugLoop::new(),
             send_queue: VecDeque::new(),
             sub_poll,
+            gem_handle_refs: HashMap::new(),
         }));
         {
             let mut borrow = this.borrow_mut();
@@ -709,6 +723,11 @@ impl<'a, P: ProtocolHandler> Client<'a, P> {
         unsafe {
             drm_virtgpu_resource_info(self.gpu_ctx.fd.as_raw_fd() as c_int, &mut res_info)?;
         }
+        // Count a live reference; only the last finalizer for this handle closes it.
+        self.gem_handle_refs
+            .entry(to_handle.handle)
+            .and_modify(|refcount| *refcount += 1)
+            .or_insert(1);
         Ok((
             CrossDomainResource {
                 identifier: res_info.res_handle,


### PR DESCRIPTION
A DRI3 PixmapFromBuffers request for a multi-plane buffer (or any buffer whose planes share one backing object) passes several dma-buf fds that all resolve to the same virtgpu GEM handle, because drm_prime_fd_to_handle deduplicates imports of the same underlying object. vgpu_id_from_prime creates one GemHandleFinalizer per fd, so once the request has been forwarded the bridge calls drm_gem_close on that handle once per fd. The first close frees the handle; each subsequent close of the now-invalid handle returns EINVAL (ENOENT on some drivers), which propagated out of process_socket and tore down the entire X11 client connection.

This is easy to hit with the Intel iris native context, which hands DRI3 a multi-plane (CCS-aux) buffer: glmark2 and other GL clients died with "XIO: fatal IO error 95 ... after 38 requests" the moment the first frame's pixmap was finalized.

Treat EINVAL/ENOENT from the redundant close as success: the handle is already gone, which is exactly the intended outcome.

Tested on an Intel Raptor Lake-U iGPU (8086:a721) with the iris native context, with the host iGPU bound to both the i915 and the xe kernel driver: before this change every GL client died with the XIO 95 above; after it, glmark2 runs to completion on both drivers (GL_RENDERER "Mesa Intel(R) Graphics (RPL-U)", clean exit, no finalizer/XIO errors). The fix is host-driver-independent, as the offending close is against the guest virtio-gpu device.