### PR TITLE
Remove old reference to sommelier in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Available options:
 
 ## Running graphical applications
 
-If [sommelier](https://chromium.googlesource.com/chromiumos/platform2/+/master/vm_tools/sommelier) is installed in your system, `muvm` will use it to connect to the Wayland session on the hosts, allowing you to run graphical applications in the microVM.
+If `DISPLAY` is set, `muvm` uses X11 forwarding to allow you to run graphical applications in the microVM.
 
 GPU acceleration is also enabled on systems supporting [DRM native context](https://indico.freedesktop.org/event/2/contributions/53/attachments/76/121/XDC2022_%20virtgpu%20drm%20native%20context.pdf) (freedreno, amdgpu, asahi).
 


### PR DESCRIPTION
Hi, I noticed the README still mentions sommelier but my understanding is that support for that was removed a while ago. This PR updates the README to note the current X11 forwarding support.