### PR TITLE
ci: consume libkrun.h from stable branch

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install libclang-dev libudev-dev
 
       - name: Download libkrun.h
-        run: sudo curl -o /usr/include/libkrun.h https://raw.githubusercontent.com/containers/libkrun/refs/heads/main/include/libkrun.h
+        run: sudo curl -o /usr/include/libkrun.h https://raw.githubusercontent.com/libkrun/libkrun/refs/heads/stable-1.19.x/include/libkrun.h
 
       - name: Download libkrun.pc
         run: sudo curl -o /usr/lib/x86_64-linux-gnu/pkgconfig/libkrun.pc https://gist.githubusercontent.com/slp/b5761d225d96d2c8879392a7b1611aee/raw/79b81aaabc34648d27916f4abcf7502d98915c50/libkrun-ubuntu.pc


### PR DESCRIPTION
The main branch of libkrun is targetting 2.0, which introduces a new API. As we're still using the 1.x API, let's change CI to consume libkrun.h from an stable branch.